### PR TITLE
Add elem size to merkleizeWithMixin

### DIFF
--- a/proof.go
+++ b/proof.go
@@ -14,7 +14,7 @@ import (
 // efficient than VerifyMultiproof for proving one leaf.
 func VerifyProof(root []byte, proof *Proof) (bool, error) {
 	if len(proof.Hashes) != getPathLength(proof.Index) {
-		return false, errors.New("Invalid proof length")
+		return false, errors.New("invalid proof length")
 	}
 
 	node := proof.Leaf[:]
@@ -37,12 +37,12 @@ func VerifyProof(root []byte, proof *Proof) (bool, error) {
 // VerifyMultiproof verifies a proof for multiple leaves against the given root.
 func VerifyMultiproof(root []byte, proof [][]byte, leaves [][]byte, indices []int) (bool, error) {
 	if len(leaves) != len(indices) {
-		return false, errors.New("Number of leaves and indices mismatch")
+		return false, errors.New("number of leaves and indices mismatch")
 	}
 
 	reqIndices := getRequiredIndices(indices)
 	if len(reqIndices) != len(proof) {
-		return false, fmt.Errorf("Number of proof hashes %d and required indices %d mismatch", len(proof), len(reqIndices))
+		return false, fmt.Errorf("number of proof hashes %d and required indices %d mismatch", len(proof), len(reqIndices))
 	}
 
 	keys := make([]int, len(indices)+len(reqIndices))
@@ -80,7 +80,7 @@ func VerifyMultiproof(root []byte, proof [][]byte, leaves [][]byte, indices []in
 		left, hasLeft := db[(k|1)^1]
 		right, hasRight := db[k|1]
 		if !hasRight || !hasLeft {
-			return false, fmt.Errorf("Proof is missing required nodes, either %d or %d", (k|1)^1, k|1)
+			return false, fmt.Errorf("proof is missing required nodes, either %d or %d", (k|1)^1, k|1)
 		}
 
 		copy(tmp[:32], left[:])
@@ -93,7 +93,7 @@ func VerifyMultiproof(root []byte, proof [][]byte, leaves [][]byte, indices []in
 
 	res, ok := db[1]
 	if !ok {
-		return false, fmt.Errorf("Root was not computed during proof verification")
+		return false, fmt.Errorf("root was not computed during proof verification")
 	}
 
 	return bytes.Equal(res, root), nil

--- a/spectests/structs_encoding.go
+++ b/spectests/structs_encoding.go
@@ -3009,7 +3009,7 @@ func (b *BeaconState) HashTreeRootWith(hh ssz.HashWalker) (err error) {
 			hh.Append(i)
 		}
 		numItems := uint64(len(b.HistoricalRoots))
-		hh.MerkleizeWithMixin(subIndx, numItems, ssz.CalculateLimit(16777216, numItems, 32))
+		hh.MerkleizeWithMixin(subIndx, numItems, 16777216)
 	}
 
 	// Field (8) 'Eth1Data'
@@ -5137,7 +5137,7 @@ func (b *BeaconStateAltair) HashTreeRootWith(hh ssz.HashWalker) (err error) {
 			hh.Append(i)
 		}
 		numItems := uint64(len(b.HistoricalRoots))
-		hh.MerkleizeWithMixin(subIndx, numItems, ssz.CalculateLimit(16777216, numItems, 32))
+		hh.MerkleizeWithMixin(subIndx, numItems, 16777216)
 	}
 
 	// Field (8) 'Eth1Data'
@@ -5963,7 +5963,7 @@ func (b *BeaconStateBellatrix) HashTreeRootWith(hh ssz.HashWalker) (err error) {
 			hh.Append(i)
 		}
 		numItems := uint64(len(b.HistoricalRoots))
-		hh.MerkleizeWithMixin(subIndx, numItems, ssz.CalculateLimit(16777216, numItems, 32))
+		hh.MerkleizeWithMixin(subIndx, numItems, 16777216)
 	}
 
 	// Field (8) 'Eth1Data'

--- a/sszgen/hash.go
+++ b/sszgen/hash.go
@@ -49,6 +49,7 @@ func (v *Value) hashRoots(isList bool, elem Type) string {
 			// we need to use PutBytes in order to hash the result since
 			// is higher than 32 bytes
 			appendFn = "PutBytes"
+			elemSize = v.e.s
 		} else {
 			appendFn = "Append"
 			elemSize = 32
@@ -61,17 +62,28 @@ func (v *Value) hashRoots(isList bool, elem Type) string {
 
 	var merkleize string
 	if isList {
+		// the limit for merkleize with mixin depends on the internal type
+		// if the type is basic, the size depends on CalculateLimit
+		// if the type is complex (TypeVector), the limit is the size.
+		// TODO: Generalize a list of complex objects
+		isComplex := false
+		if v.e.t == TypeBytes {
+			// TypeVector alias
+			isComplex = true
+		}
+
 		tmpl := `
 		numItems := uint64(len(::.{{.name}}))
 		if ssz.EnableVectorizedHTR {
-			hh.MerkleizeWithMixinVectorizedHTR(subIndx, numItems, ssz.CalculateLimit({{.listSize}}, numItems, {{.elemSize}}))
+			hh.MerkleizeWithMixinVectorizedHTR(subIndx, numItems, {{if .isComplex}} {{.listSize}} {{ else }} ssz.CalculateLimit({{.listSize}}, numItems, {{.elemSize}}) {{ end }})
 		} else {
-			hh.MerkleizeWithMixin(subIndx, numItems, ssz.CalculateLimit({{.listSize}}, numItems, {{.elemSize}}))
+			hh.MerkleizeWithMixin(subIndx, numItems, {{if .isComplex}} {{.listSize}} {{ else }} ssz.CalculateLimit({{.listSize}}, numItems, {{.elemSize}}) {{ end }})
 		}`
 		merkleize = execTmpl(tmpl, map[string]interface{}{
-			"name":     v.name,
-			"listSize": v.s,
-			"elemSize": elemSize,
+			"name":      v.name,
+			"listSize":  v.s,
+			"elemSize":  elemSize,
+			"isComplex": isComplex,
 		})
 
 		// when doing []uint64 we need to round up the Hasher bytes to 32

--- a/tree.go
+++ b/tree.go
@@ -121,7 +121,7 @@ func TreeFromNodes(leaves []*Node) (*Node, error) {
 	}
 
 	if !isPowerOfTwo(numLeaves) {
-		return nil, errors.New("Number of leaves should be a power of 2")
+		return nil, errors.New("number of leaves should be a power of 2")
 	}
 
 	numNodes := numLeaves*2 - 1
@@ -142,7 +142,7 @@ func TreeFromNodes(leaves []*Node) (*Node, error) {
 func TreeFromNodesWithMixin(leaves []*Node, num, limit int) (*Node, error) {
 	numLeaves := len(leaves)
 	if !isPowerOfTwo(limit) {
-		return nil, errors.New("Size of tree should be a power of 2")
+		return nil, errors.New("size of tree should be a power of 2")
 	}
 
 	allLeaves := make([]*Node, limit)


### PR DESCRIPTION
This is cherry-picked from upstream fastssz at b166e8d8cb77. This fixes mixin size of embedded ssz Vectors.
See https://github.com/ferranbt/fastssz/issues/111 for context.