### PR TITLE
improved error messages, inlining bools

### DIFF
--- a/hasher.go
+++ b/hasher.go
@@ -2,6 +2,7 @@ package ssz
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"hash"
 	"math/bits"
@@ -14,9 +15,9 @@ import (
 var (
 	// ErrIncorrectByteSize means that the byte size is incorrect
 	ErrIncorrectByteSize = fmt.Errorf("incorrect byte size")
-
 	// ErrIncorrectListSize means that the size of the list is incorrect
 	ErrIncorrectListSize = fmt.Errorf("incorrect list size")
+	ErrRootSizeInvalid   = errors.New("root must be 32 bytes")
 )
 
 var zeroHashes [65][32]byte
@@ -295,7 +296,7 @@ func (h *Hasher) MerkleizeWithMixin(indx int, num, limit uint64) {
 // HashRoot creates the hash final hash root
 func (h *Hasher) HashRoot() (res [32]byte, err error) {
 	if len(h.buf) != 32 {
-		err = fmt.Errorf("expected 32 byte size")
+		err = ErrRootSizeInvalid
 		return
 	}
 	copy(res[:], h.buf)

--- a/sszgen/unmarshal.go
+++ b/sszgen/unmarshal.go
@@ -95,11 +95,18 @@ func (v *Value) unmarshal(dst string) string {
 		return v.unmarshalList()
 
 	case TypeBool:
-		return fmt.Sprintf("::.%s = ssz.UnmarshalBool(%s)", v.name, dst)
+		return unbTmpl(v.name, dst)
 
 	default:
 		panic(fmt.Errorf("unmarshal not implemented for type %d", v.t))
 	}
+}
+
+func unbTmpl(name, dst string) string {
+	return fmt.Sprintf(`::.%s, err = ssz.DecodeBool(%s)
+	    if err != nil {
+		return err
+	}`, name, dst)
 }
 
 func (v *Value) unmarshalList() string {


### PR DESCRIPTION
We reworded or replaced most of the badly worded error messages in the last PR, but there were still a few more which can be confusing out of context. This PR cleans those up.