### PR TITLE
Use generics for various encoding/decoding operations for Uint values

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -5,11 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Go test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.15.10'
+          go-version-file: go.mod
       - name: Validate spec
         run: ./scripts/ci-validate-specs.sh
       - name: Download spec tests

--- a/decode.go
+++ b/decode.go
@@ -179,16 +179,22 @@ func ExtendUint[T uints](b []T, needLen int) []T {
 }
 
 // ExtendUint64 extends a uint64 buffer to a given size.
+//
+// Deprecated: use ExtendUint instead.
 func ExtendUint64(b []uint64, needLen int) []uint64 {
 	return ExtendUint(b, needLen)
 }
 
 // ExtendUint16 extends a uint16 buffer to a given size.
+//
+// Deprecated: use ExtendUint instead.
 func ExtendUint16(b []uint16, needLen int) []uint16 {
 	return ExtendUint(b, needLen)
 }
 
 // ExtendUint8 extends a uint8 buffer to a given size.
+//
+// Deprecated: use ExtendUint instead.
 func ExtendUint8(b []uint8, needLen int) []uint8 {
 	return ExtendUint(b, needLen)
 }

--- a/decode.go
+++ b/decode.go
@@ -165,31 +165,32 @@ func DivideInt(a, b int) (int, bool) {
 	return a / b, a%b == 0
 }
 
-// ExtendUint64 extends a uint64 buffer to a given size
+type uints interface {
+	~uint8 | ~uint16 | ~uint64
+}
+
+// ExtendUint extends an unsigned integer buffer to a given size.
+func ExtendUint[T uints](b []T, needLen int) []T {
+	b = b[:cap(b)]
+	if n := needLen - cap(b); n > 0 {
+		b = append(b, make([]T, n)...)
+	}
+	return b[:needLen]
+}
+
+// ExtendUint64 extends a uint64 buffer to a given size.
 func ExtendUint64(b []uint64, needLen int) []uint64 {
-	b = b[:cap(b)]
-	if n := needLen - cap(b); n > 0 {
-		b = append(b, make([]uint64, n)...)
-	}
-	return b[:needLen]
+	return ExtendUint(b, needLen)
 }
 
-// ExtendUint16 extends a uint16 buffer to a given size
+// ExtendUint16 extends a uint16 buffer to a given size.
 func ExtendUint16(b []uint16, needLen int) []uint16 {
-	b = b[:cap(b)]
-	if n := needLen - cap(b); n > 0 {
-		b = append(b, make([]uint16, n)...)
-	}
-	return b[:needLen]
+	return ExtendUint(b, needLen)
 }
 
-// ExtendUint8 extends a uint16 buffer to a given size
+// ExtendUint8 extends a uint8 buffer to a given size.
 func ExtendUint8(b []uint8, needLen int) []uint8 {
-	b = b[:cap(b)]
-	if n := needLen - cap(b); n > 0 {
-		b = append(b, make([]uint8, n)...)
-	}
-	return b[:needLen]
+	return ExtendUint(b, needLen)
 }
 
 // ReadOffset reads an offset from buf

--- a/decode.go
+++ b/decode.go
@@ -5,28 +5,58 @@ import (
 	"errors"
 	"fmt"
 	"math/bits"
+	"unsafe"
 )
 
 const bytesPerLengthOffset = 4
 
-// UnmarshallUint64 unmarshals a little endian uint64 from the src input
+type unmarshallUints interface {
+	~uint8 | ~uint16 | ~uint32 | ~uint64
+}
+
+// UnmarshallUint unmarshals a little endian uint8, uint16, uint32, or uint64 from the src input.
+func UnmarshallUint[T unmarshallUints](src []byte) T {
+	var zero T
+	switch unsafe.Sizeof(zero) {
+	case 1:
+		return T(src[0])
+	case 2:
+		return T(binary.LittleEndian.Uint16(src[:2]))
+	case 4:
+		return T(binary.LittleEndian.Uint32(src[:4]))
+	case 8:
+		return T(binary.LittleEndian.Uint64(src[:8]))
+	default:
+		panic("unsupported uint size")
+	}
+}
+
+// UnmarshallUint64 unmarshals a little endian uint64 from the src input.
+//
+// Deprecated: use UnmarshallUint instead.
 func UnmarshallUint64(src []byte) uint64 {
-	return binary.LittleEndian.Uint64(src)
+	return UnmarshallUint[uint64](src)
 }
 
-// UnmarshallUint32 unmarshals a little endian uint32 from the src input
+// UnmarshallUint32 unmarshals a little endian uint32 from the src input.
+//
+// Deprecated: use UnmarshallUint instead.
 func UnmarshallUint32(src []byte) uint32 {
-	return binary.LittleEndian.Uint32(src[:4])
+	return UnmarshallUint[uint32](src)
 }
 
-// UnmarshallUint16 unmarshals a little endian uint16 from the src input
+// UnmarshallUint16 unmarshals a little endian uint16 from the src input.
+//
+// Deprecated: use UnmarshallUint instead.
 func UnmarshallUint16(src []byte) uint16 {
-	return binary.LittleEndian.Uint16(src[:2])
+	return UnmarshallUint[uint16](src)
 }
 
-// UnmarshallUint8 unmarshals a little endian uint8 from the src input
+// UnmarshallUint8 unmarshals a little endian uint8 from the src input.
+//
+// Deprecated: use UnmarshallUint instead.
 func UnmarshallUint8(src []byte) uint8 {
-	return uint8(src[0])
+	return UnmarshallUint[uint8](src)
 }
 
 // UnmarshalBool unmarshals a boolean from the src input

--- a/decode_test.go
+++ b/decode_test.go
@@ -94,3 +94,67 @@ func TestBitlist_MaxValue(t *testing.T) {
 		})
 	}
 }
+
+func TestExtendUint(t *testing.T) {
+	t.Run("uint8", func(t *testing.T) {
+		buf := make([]uint8, 2, 4)
+		buf[0] = 1
+		buf[1] = 2
+
+		base := &buf[:cap(buf)][0]
+		got := ExtendUint(buf, 4)
+
+		if len(got) != 4 {
+			t.Fatalf("expected len 4, got %d", len(got))
+		}
+		if cap(got) != 4 {
+			t.Fatalf("expected cap 4, got %d", cap(got))
+		}
+		if &got[0] != base {
+			t.Fatal("expected ExtendUint to reuse backing array")
+		}
+		if got[0] != 1 || got[1] != 2 || got[2] != 0 || got[3] != 0 {
+			t.Fatalf("unexpected result: %v", got)
+		}
+	})
+
+	t.Run("uint16", func(t *testing.T) {
+		buf := []uint16{3}
+
+		got := ExtendUint(buf, 3)
+
+		if len(got) != 3 {
+			t.Fatalf("expected len 3, got %d", len(got))
+		}
+		if got[0] != 3 || got[1] != 0 || got[2] != 0 {
+			t.Fatalf("unexpected result: %v", got)
+		}
+	})
+
+	t.Run("uint64", func(t *testing.T) {
+		buf := make([]uint64, 1)
+		buf[0] = 9
+
+		got := ExtendUint(buf, 2)
+
+		if len(got) != 2 {
+			t.Fatalf("expected len 2, got %d", len(got))
+		}
+		if got[0] != 9 || got[1] != 0 {
+			t.Fatalf("unexpected result: %v", got)
+		}
+	})
+
+	t.Run("shrink", func(t *testing.T) {
+		buf := []uint16{5, 6, 7}
+
+		got := ExtendUint(buf, 2)
+
+		if len(got) != 2 {
+			t.Fatalf("expected len 2, got %d", len(got))
+		}
+		if got[0] != 5 || got[1] != 6 {
+			t.Fatalf("unexpected result: %v", got)
+		}
+	})
+}

--- a/decode_test.go
+++ b/decode_test.go
@@ -96,6 +96,20 @@ func TestBitlist_MaxValue(t *testing.T) {
 }
 
 func TestExtendUint(t *testing.T) {
+	t.Run("uint64 alias", func(t *testing.T) {
+		type aliasedUint64 = uint64
+
+		buf := []aliasedUint64{4}
+		got := ExtendUint(buf, 2)
+
+		if len(got) != 2 {
+			t.Fatalf("expected len 2, got %d", len(got))
+		}
+		if got[0] != 4 || got[1] != 0 {
+			t.Fatalf("unexpected result: %v", got)
+		}
+	})
+
 	t.Run("uint8", func(t *testing.T) {
 		buf := make([]uint8, 2, 4)
 		buf[0] = 1

--- a/decode_test.go
+++ b/decode_test.go
@@ -1,6 +1,9 @@
 package ssz
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -8,6 +11,8 @@ import (
 	"strings"
 	"testing"
 )
+
+type aliasedUint64 uint64
 
 func TestBitlist(t *testing.T) {
 	res := []string{}
@@ -171,4 +176,52 @@ func TestExtendUint(t *testing.T) {
 			t.Fatalf("unexpected result: %v", got)
 		}
 	})
+}
+
+func TestUnmarshallUintAcceptsNamedUint64(t *testing.T) {
+	got := UnmarshallUint[aliasedUint64]([]byte{9, 0, 0, 0, 0, 0, 0, 0})
+	if got != 9 {
+		t.Fatalf("unexpected result: %v", got)
+	}
+}
+
+func TestDeprecatedUnmarshallWrappersCallUnmarshallUint(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "decode.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range []string{"UnmarshallUint64", "UnmarshallUint32", "UnmarshallUint16", "UnmarshallUint8"} {
+		found := false
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Name.Name != name {
+				continue
+			}
+			found = true
+			if len(fn.Body.List) != 1 {
+				t.Fatalf("expected %s to have exactly one statement", name)
+			}
+			ret, ok := fn.Body.List[0].(*ast.ReturnStmt)
+			if !ok || len(ret.Results) != 1 {
+				t.Fatalf("expected %s to return a direct call", name)
+			}
+			call, ok := ret.Results[0].(*ast.CallExpr)
+			if !ok {
+				t.Fatalf("expected %s to return a call", name)
+			}
+			ident, ok := call.Fun.(*ast.IndexExpr)
+			if !ok {
+				t.Fatalf("expected %s to call generic UnmarshallUint", name)
+			}
+			fun, ok := ident.X.(*ast.Ident)
+			if !ok || fun.Name != "UnmarshallUint" {
+				t.Fatalf("expected %s to call UnmarshallUint", name)
+			}
+		}
+		if !found {
+			t.Fatalf("did not find %s", name)
+		}
+	}
 }

--- a/encode.go
+++ b/encode.go
@@ -92,5 +92,5 @@ func MarshalBool(dst []byte, b bool) []byte {
 
 // WriteOffset writes an offset to dst
 func WriteOffset(dst []byte, i int) []byte {
-	return MarshalUint32(dst, uint32(i))
+	return MarshalUint(dst, uint32(i))
 }

--- a/encode.go
+++ b/encode.go
@@ -3,6 +3,7 @@ package ssz
 import (
 	"encoding/binary"
 	"fmt"
+	"unsafe"
 )
 
 // MarshalSSZ marshals an object
@@ -33,25 +34,52 @@ func ErrListTooBigFn(name string, found, max int) error {
 	return fmt.Errorf("%s (%v): max expected %d and %d found", name, ErrListTooBig, max, found)
 }
 
-// MarshalUint64 marshals a little endian uint64 to dst
+type marshalUints interface {
+	~uint8 | ~uint16 | ~uint32 | ~uint64
+}
+
+// MarshalUint marshals a little endian uint8, uint16, uint32, or uint64 to dst.
+func MarshalUint[T marshalUints](dst []byte, i T) []byte {
+	switch unsafe.Sizeof(i) {
+	case 1:
+		return append(dst, byte(i))
+	case 2:
+		return binary.LittleEndian.AppendUint16(dst, uint16(i))
+	case 4:
+		return binary.LittleEndian.AppendUint32(dst, uint32(i))
+	case 8:
+		return binary.LittleEndian.AppendUint64(dst, uint64(i))
+	default:
+		panic("unsupported uint size")
+	}
+}
+
+// MarshalUint64 marshals a little endian uint64 to dst.
+//
+// Deprecated: use MarshalUint instead.
 func MarshalUint64(dst []byte, i uint64) []byte {
-	return binary.LittleEndian.AppendUint64(dst, i)
+	return MarshalUint(dst, i)
 }
 
-// MarshalUint32 marshals a little endian uint32 to dst
+// MarshalUint32 marshals a little endian uint32 to dst.
+//
+// Deprecated: use MarshalUint instead.
 func MarshalUint32(dst []byte, i uint32) []byte {
-	return binary.LittleEndian.AppendUint32(dst, i)
+	return MarshalUint(dst, i)
 }
 
-// MarshalUint16 marshals a little endian uint16 to dst
+// MarshalUint16 marshals a little endian uint16 to dst.
+//
+// Deprecated: use MarshalUint instead.
 func MarshalUint16(dst []byte, i uint16) []byte {
-	return binary.LittleEndian.AppendUint16(dst, i)
+	return MarshalUint(dst, i)
 }
 
-// MarshalUint8 marshals a little endian uint8 to dst
+// MarshalUint8 marshals a little endian uint8 to dst.
+//
+// Deprecated: use MarshalUint instead.
 func MarshalUint8(dst []byte, i uint8) []byte {
-	dst = append(dst, byte(i))
-	return dst
+	return MarshalUint(dst, i)
 }
 
 // MarshalBool marshals a boolean to dst

--- a/encode.go
+++ b/encode.go
@@ -40,19 +40,15 @@ type marshalUints interface {
 
 // MarshalUint marshals a little endian uint8, uint16, uint32, or uint64 to dst.
 func MarshalUint[T marshalUints](dst []byte, i T) []byte {
-	var buf [8]byte
 	switch unsafe.Sizeof(i) {
 	case 1:
 		return append(dst, byte(i))
 	case 2:
-		binary.LittleEndian.PutUint16(buf[:2], uint16(i))
-		return append(dst, buf[:2]...)
+		return binary.LittleEndian.AppendUint16(dst, uint16(i))
 	case 4:
-		binary.LittleEndian.PutUint32(buf[:4], uint32(i))
-		return append(dst, buf[:4]...)
+		return binary.LittleEndian.AppendUint32(dst, uint32(i))
 	case 8:
-		binary.LittleEndian.PutUint64(buf[:8], uint64(i))
-		return append(dst, buf[:8]...)
+		return binary.LittleEndian.AppendUint64(dst, uint64(i))
 	default:
 		panic("unsupported uint size")
 	}

--- a/encode.go
+++ b/encode.go
@@ -40,15 +40,19 @@ type marshalUints interface {
 
 // MarshalUint marshals a little endian uint8, uint16, uint32, or uint64 to dst.
 func MarshalUint[T marshalUints](dst []byte, i T) []byte {
+	var buf [8]byte
 	switch unsafe.Sizeof(i) {
 	case 1:
 		return append(dst, byte(i))
 	case 2:
-		return binary.LittleEndian.AppendUint16(dst, uint16(i))
+		binary.LittleEndian.PutUint16(buf[:2], uint16(i))
+		return append(dst, buf[:2]...)
 	case 4:
-		return binary.LittleEndian.AppendUint32(dst, uint32(i))
+		binary.LittleEndian.PutUint32(buf[:4], uint32(i))
+		return append(dst, buf[:4]...)
 	case 8:
-		return binary.LittleEndian.AppendUint64(dst, uint64(i))
+		binary.LittleEndian.PutUint64(buf[:8], uint64(i))
+		return append(dst, buf[:8]...)
 	default:
 		panic("unsupported uint size")
 	}

--- a/encode_test.go
+++ b/encode_test.go
@@ -54,3 +54,32 @@ func TestDeprecatedMarshalWrappersCallMarshalUint(t *testing.T) {
 		}
 	}
 }
+
+func TestWriteOffsetUsesMarshalUint(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "encode.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "WriteOffset" {
+			continue
+		}
+		ret, ok := fn.Body.List[0].(*ast.ReturnStmt)
+		if !ok || len(ret.Results) != 1 {
+			t.Fatal("expected WriteOffset to return a direct call")
+		}
+		call, ok := ret.Results[0].(*ast.CallExpr)
+		if !ok {
+			t.Fatal("expected WriteOffset to return a call")
+		}
+		ident, ok := call.Fun.(*ast.Ident)
+		if !ok || ident.Name != "MarshalUint" {
+			t.Fatal("expected WriteOffset to call MarshalUint")
+		}
+		return
+	}
+	t.Fatal("did not find WriteOffset")
+}

--- a/encode_test.go
+++ b/encode_test.go
@@ -1,0 +1,56 @@
+package ssz
+
+import (
+	"bytes"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+type slot uint64
+
+func TestMarshalUintAcceptsNamedUint64(t *testing.T) {
+	got := MarshalUint(nil, slot(9))
+	want := []byte{9, 0, 0, 0, 0, 0, 0, 0}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("unexpected result: %v", got)
+	}
+}
+
+func TestDeprecatedMarshalWrappersCallMarshalUint(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "encode.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range []string{"MarshalUint64", "MarshalUint32", "MarshalUint16", "MarshalUint8"} {
+		found := false
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Name.Name != name {
+				continue
+			}
+			found = true
+			if len(fn.Body.List) != 1 {
+				t.Fatalf("expected %s to have exactly one statement", name)
+			}
+			ret, ok := fn.Body.List[0].(*ast.ReturnStmt)
+			if !ok || len(ret.Results) != 1 {
+				t.Fatalf("expected %s to return a direct call", name)
+			}
+			call, ok := ret.Results[0].(*ast.CallExpr)
+			if !ok {
+				t.Fatalf("expected %s to return a call", name)
+			}
+			ident, ok := call.Fun.(*ast.Ident)
+			if !ok || ident.Name != "MarshalUint" {
+				t.Fatalf("expected %s to call MarshalUint", name)
+			}
+		}
+		if !found {
+			t.Fatalf("did not find %s", name)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prysmaticlabs/fastssz
 
-go 1.18
+go 1.19
 
 require (
 	github.com/golang/snappy v0.0.3

--- a/hasher.go
+++ b/hasher.go
@@ -190,14 +190,14 @@ func AppendUint[T appendUints](h *Hasher, i T) {
 //
 // Deprecated: use AppendUint instead.
 func (h *Hasher) AppendUint8(i uint8) {
-	h.buf = MarshalUint8(h.buf, i)
+	AppendUint(h, i)
 }
 
 // AppendUint64 appends a uint64 without 32-byte padding.
 //
 // Deprecated: use AppendUint instead.
 func (h *Hasher) AppendUint64(i uint64) {
-	h.buf = MarshalUint64(h.buf, i)
+	AppendUint(h, i)
 }
 
 func (h *Hasher) Append(i []byte) {

--- a/hasher.go
+++ b/hasher.go
@@ -1,7 +1,6 @@
 package ssz
 
 import (
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"hash"
@@ -122,30 +121,37 @@ func (h *Hasher) AppendBytes32(b []byte) {
 	}
 }
 
-// PutUint64 appends a uint64 in 32 bytes
+// PutUint appends a uint8, uint16, uint32, or uint64 in 32 bytes.
+func PutUint[T appendUints](h *Hasher, i T) {
+	h.AppendBytes32(MarshalUint(nil, i))
+}
+
+// PutUint64 appends a uint64 in 32 bytes.
+//
+// Deprecated: use PutUint instead.
 func (h *Hasher) PutUint64(i uint64) {
-	buf := make([]byte, 8)
-	binary.LittleEndian.PutUint64(buf, i)
-	h.AppendBytes32(buf)
+	PutUint(h, i)
 }
 
-// PutUint32 appends a uint32 in 32 bytes
+// PutUint32 appends a uint32 in 32 bytes.
+//
+// Deprecated: use PutUint instead.
 func (h *Hasher) PutUint32(i uint32) {
-	buf := make([]byte, 4)
-	binary.LittleEndian.PutUint32(buf, i)
-	h.AppendBytes32(buf)
+	PutUint(h, i)
 }
 
-// PutUint16 appends a uint16 in 32 bytes
+// PutUint16 appends a uint16 in 32 bytes.
+//
+// Deprecated: use PutUint instead.
 func (h *Hasher) PutUint16(i uint16) {
-	buf := make([]byte, 2)
-	binary.LittleEndian.PutUint16(buf, i)
-	h.AppendBytes32(buf)
+	PutUint(h, i)
 }
 
-// PutUint16 appends a uint16 in 32 bytes
+// PutUint8 appends a uint8 in 32 bytes.
+//
+// Deprecated: use PutUint instead.
 func (h *Hasher) PutUint8(i uint8) {
-	h.AppendBytes32([]byte{byte(i)})
+	PutUint(h, i)
 }
 
 func CalculateLimit(maxCapacity, numItems, size uint64) uint64 {

--- a/hasher.go
+++ b/hasher.go
@@ -7,6 +7,7 @@ import (
 	"hash"
 	"math/bits"
 	"sync"
+	"unsafe"
 
 	"github.com/minio/sha256-simd"
 	"github.com/prysmaticlabs/gohashtree"
@@ -165,10 +166,36 @@ func (h *Hasher) FillUpTo32() {
 	}
 }
 
+type appendUints interface {
+	~uint8 | ~uint16 | ~uint32 | ~uint64
+}
+
+// AppendUint appends a uint8, uint16, uint32, or uint64 value without 32-byte padding.
+func AppendUint[T appendUints](h *Hasher, i T) {
+	switch unsafe.Sizeof(i) {
+	case 1:
+		h.buf = MarshalUint8(h.buf, uint8(i))
+	case 2:
+		h.buf = MarshalUint16(h.buf, uint16(i))
+	case 4:
+		h.buf = MarshalUint32(h.buf, uint32(i))
+	case 8:
+		h.buf = MarshalUint64(h.buf, uint64(i))
+	default:
+		panic("unsupported uint size")
+	}
+}
+
+// AppendUint8 appends a uint8 without 32-byte padding.
+//
+// Deprecated: use AppendUint instead.
 func (h *Hasher) AppendUint8(i uint8) {
 	h.buf = MarshalUint8(h.buf, i)
 }
 
+// AppendUint64 appends a uint64 without 32-byte padding.
+//
+// Deprecated: use AppendUint instead.
 func (h *Hasher) AppendUint64(i uint64) {
 	h.buf = MarshalUint64(h.buf, i)
 }
@@ -202,7 +229,7 @@ func (h *Hasher) PutRootVector(b [][]byte, maxCapacity ...uint64) error {
 func (h *Hasher) PutUint64Array(b []uint64, maxCapacity ...uint64) {
 	indx := h.Index()
 	for _, i := range b {
-		h.AppendUint64(i)
+		h.buf = MarshalUint64(h.buf, i)
 	}
 
 	// pad zero bytes to the left

--- a/hasher.go
+++ b/hasher.go
@@ -6,7 +6,6 @@ import (
 	"hash"
 	"math/bits"
 	"sync"
-	"unsafe"
 
 	"github.com/minio/sha256-simd"
 	"github.com/prysmaticlabs/gohashtree"
@@ -178,18 +177,7 @@ type appendUints interface {
 
 // AppendUint appends a uint8, uint16, uint32, or uint64 value without 32-byte padding.
 func AppendUint[T appendUints](h *Hasher, i T) {
-	switch unsafe.Sizeof(i) {
-	case 1:
-		h.buf = MarshalUint8(h.buf, uint8(i))
-	case 2:
-		h.buf = MarshalUint16(h.buf, uint16(i))
-	case 4:
-		h.buf = MarshalUint32(h.buf, uint32(i))
-	case 8:
-		h.buf = MarshalUint64(h.buf, uint64(i))
-	default:
-		panic("unsupported uint size")
-	}
+	h.buf = MarshalUint(h.buf, i)
 }
 
 // AppendUint8 appends a uint8 without 32-byte padding.
@@ -235,7 +223,7 @@ func (h *Hasher) PutRootVector(b [][]byte, maxCapacity ...uint64) error {
 func (h *Hasher) PutUint64Array(b []uint64, maxCapacity ...uint64) {
 	indx := h.Index()
 	for _, i := range b {
-		h.buf = MarshalUint64(h.buf, i)
+		h.buf = MarshalUint(h.buf, i)
 	}
 
 	// pad zero bytes to the left
@@ -322,7 +310,7 @@ func (h *Hasher) MerkleizeWithMixin(indx int, num, limit uint64) {
 	for indx := range sizemix {
 		sizemix[indx] = 0
 	}
-	MarshalUint64(sizemix[:0], num)
+	MarshalUint(sizemix[:0], num)
 	h.buf = append(h.buf[:indx], h.doHash(input, input, sizemix)...)
 }
 

--- a/hasher_test.go
+++ b/hasher_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 )
 
+type validatorIndex uint64
+
 func TestNextPowerOfTwo(t *testing.T) {
 	cases := []struct {
 		Num, Res uint64
@@ -34,5 +36,15 @@ func TestMerkleize8ByteVector(t *testing.T) {
 	result := merkleizeInput([]byte{'1', '2', '3', '4', '5', '6', '7', '8'}, 0)
 	if !bytes.Equal(result, []byte{49, 50, 51, 52, 53, 54, 55, 56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}) {
 		t.Fatalf("Unexpected result: %v", result)
+	}
+}
+
+func TestAppendUintAcceptsNamedUint64(t *testing.T) {
+	var h Hasher
+	AppendUint(&h, validatorIndex(7))
+
+	want := MarshalUint64(nil, 7)
+	if !bytes.Equal(h.buf, want) {
+		t.Fatalf("unexpected result: %v", h.buf)
 	}
 }

--- a/hasher_test.go
+++ b/hasher_test.go
@@ -2,6 +2,9 @@ package ssz
 
 import (
 	"bytes"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"testing"
 )
 
@@ -46,5 +49,42 @@ func TestAppendUintAcceptsNamedUint64(t *testing.T) {
 	want := MarshalUint64(nil, 7)
 	if !bytes.Equal(h.buf, want) {
 		t.Fatalf("unexpected result: %v", h.buf)
+	}
+}
+
+func TestDeprecatedAppendWrappersCallAppendUint(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "hasher.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range []string{"AppendUint8", "AppendUint64"} {
+		found := false
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Name.Name != name {
+				continue
+			}
+			found = true
+			if len(fn.Body.List) != 1 {
+				t.Fatalf("expected %s to have exactly one statement", name)
+			}
+			exprStmt, ok := fn.Body.List[0].(*ast.ExprStmt)
+			if !ok {
+				t.Fatalf("expected %s to delegate with a direct call", name)
+			}
+			call, ok := exprStmt.X.(*ast.CallExpr)
+			if !ok {
+				t.Fatalf("expected %s body to be a call", name)
+			}
+			ident, ok := call.Fun.(*ast.Ident)
+			if !ok || ident.Name != "AppendUint" {
+				t.Fatalf("expected %s to call AppendUint", name)
+			}
+		}
+		if !found {
+			t.Fatalf("did not find %s", name)
+		}
 	}
 }

--- a/hasher_test.go
+++ b/hasher_test.go
@@ -136,3 +136,35 @@ func TestDeprecatedPutWrappersCallPutUint(t *testing.T) {
 		}
 	}
 }
+
+func TestAppendUintUsesMarshalUintInternally(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "hasher.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "AppendUint" {
+			continue
+		}
+		callsMarshalUint := false
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			ident, ok := call.Fun.(*ast.Ident)
+			if ok && ident.Name == "MarshalUint" {
+				callsMarshalUint = true
+			}
+			return true
+		})
+		if !callsMarshalUint {
+			t.Fatal("expected AppendUint to use MarshalUint internally")
+		}
+		return
+	}
+	t.Fatal("did not find AppendUint")
+}

--- a/hasher_test.go
+++ b/hasher_test.go
@@ -52,6 +52,17 @@ func TestAppendUintAcceptsNamedUint64(t *testing.T) {
 	}
 }
 
+func TestPutUintAcceptsNamedUint64(t *testing.T) {
+	var h Hasher
+	PutUint(&h, validatorIndex(7))
+
+	want := make([]byte, 32)
+	copy(want, MarshalUint64(nil, 7))
+	if !bytes.Equal(h.buf, want) {
+		t.Fatalf("unexpected result: %v", h.buf)
+	}
+}
+
 func TestDeprecatedAppendWrappersCallAppendUint(t *testing.T) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "hasher.go", nil, 0)
@@ -81,6 +92,43 @@ func TestDeprecatedAppendWrappersCallAppendUint(t *testing.T) {
 			ident, ok := call.Fun.(*ast.Ident)
 			if !ok || ident.Name != "AppendUint" {
 				t.Fatalf("expected %s to call AppendUint", name)
+			}
+		}
+		if !found {
+			t.Fatalf("did not find %s", name)
+		}
+	}
+}
+
+func TestDeprecatedPutWrappersCallPutUint(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "hasher.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range []string{"PutUint64", "PutUint32", "PutUint16", "PutUint8"} {
+		found := false
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Name.Name != name {
+				continue
+			}
+			found = true
+			if len(fn.Body.List) != 1 {
+				t.Fatalf("expected %s to have exactly one statement", name)
+			}
+			exprStmt, ok := fn.Body.List[0].(*ast.ExprStmt)
+			if !ok {
+				t.Fatalf("expected %s to delegate with a direct call", name)
+			}
+			call, ok := exprStmt.X.(*ast.CallExpr)
+			if !ok {
+				t.Fatalf("expected %s body to be a call", name)
+			}
+			ident, ok := call.Fun.(*ast.Ident)
+			if !ok || ident.Name != "PutUint" {
+				t.Fatalf("expected %s to call PutUint", name)
 			}
 		}
 		if !found {

--- a/spectests/structs_encoding.go
+++ b/spectests/structs_encoding.go
@@ -19,7 +19,7 @@ func (a *AggregateAndProof) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset := int(108)
 
 	// Field (0) 'Index'
-	dst = ssz.MarshalUint64(dst, a.Index)
+	dst = ssz.MarshalUint(dst, a.Index)
 
 	// Offset (1) 'Aggregate'
 	dst = ssz.WriteOffset(dst, offset)
@@ -131,7 +131,7 @@ func (c *Checkpoint) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
 
 	// Field (0) 'Epoch'
-	dst = ssz.MarshalUint64(dst, uint64(c.Epoch))
+	dst = ssz.MarshalUint(dst, c.Epoch)
 
 	// Field (1) 'Root'
 	if size := len(c.Root); size != 32 {
@@ -202,10 +202,10 @@ func (a *AttestationData) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
 
 	// Field (0) 'Slot'
-	dst = ssz.MarshalUint64(dst, uint64(a.Slot))
+	dst = ssz.MarshalUint(dst, a.Slot)
 
 	// Field (1) 'Index'
-	dst = ssz.MarshalUint64(dst, a.Index)
+	dst = ssz.MarshalUint(dst, a.Index)
 
 	// Field (2) 'BeaconBlockHash'
 	dst = append(dst, a.BeaconBlockHash[:]...)
@@ -449,7 +449,7 @@ func (d *DepositData) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, d.WithdrawalCredentials[:]...)
 
 	// Field (2) 'Amount'
-	dst = ssz.MarshalUint64(dst, d.Amount)
+	dst = ssz.MarshalUint(dst, d.Amount)
 
 	// Field (3) 'Signature'
 	if size := len(d.Signature); size != 96 {
@@ -648,7 +648,7 @@ func (d *DepositMessage) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, d.WithdrawalCredentials...)
 
 	// Field (2) 'Amount'
-	dst = ssz.MarshalUint64(dst, d.Amount)
+	dst = ssz.MarshalUint(dst, d.Amount)
 
 	return
 }
@@ -750,7 +750,7 @@ func (i *IndexedAttestation) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < len(i.AttestationIndices); ii++ {
-		dst = ssz.MarshalUint64(dst, i.AttestationIndices[ii])
+		dst = ssz.MarshalUint(dst, i.AttestationIndices[ii])
 	}
 
 	return
@@ -879,10 +879,10 @@ func (p *PendingAttestation) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	}
 
 	// Field (2) 'InclusionDelay'
-	dst = ssz.MarshalUint64(dst, p.InclusionDelay)
+	dst = ssz.MarshalUint(dst, p.InclusionDelay)
 
 	// Field (3) 'ProposerIndex'
-	dst = ssz.MarshalUint64(dst, p.ProposerIndex)
+	dst = ssz.MarshalUint(dst, p.ProposerIndex)
 
 	// Field (0) 'AggregationBits'
 	if size := len(p.AggregationBits); size > 2048 {
@@ -1007,7 +1007,7 @@ func (f *Fork) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, f.CurrentVersion...)
 
 	// Field (2) 'Epoch'
-	dst = ssz.MarshalUint64(dst, f.Epoch)
+	dst = ssz.MarshalUint(dst, f.Epoch)
 
 	return
 }
@@ -1098,22 +1098,22 @@ func (v *Validator) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, v.WithdrawalCredentials...)
 
 	// Field (2) 'EffectiveBalance'
-	dst = ssz.MarshalUint64(dst, v.EffectiveBalance)
+	dst = ssz.MarshalUint(dst, v.EffectiveBalance)
 
 	// Field (3) 'Slashed'
 	dst = ssz.MarshalBool(dst, v.Slashed)
 
 	// Field (4) 'ActivationEligibilityEpoch'
-	dst = ssz.MarshalUint64(dst, v.ActivationEligibilityEpoch)
+	dst = ssz.MarshalUint(dst, v.ActivationEligibilityEpoch)
 
 	// Field (5) 'ActivationEpoch'
-	dst = ssz.MarshalUint64(dst, v.ActivationEpoch)
+	dst = ssz.MarshalUint(dst, v.ActivationEpoch)
 
 	// Field (6) 'ExitEpoch'
-	dst = ssz.MarshalUint64(dst, v.ExitEpoch)
+	dst = ssz.MarshalUint(dst, v.ExitEpoch)
 
 	// Field (7) 'WithdrawableEpoch'
-	dst = ssz.MarshalUint64(dst, v.WithdrawableEpoch)
+	dst = ssz.MarshalUint(dst, v.WithdrawableEpoch)
 
 	return
 }
@@ -1220,10 +1220,10 @@ func (v *VoluntaryExit) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
 
 	// Field (0) 'Epoch'
-	dst = ssz.MarshalUint64(dst, v.Epoch)
+	dst = ssz.MarshalUint(dst, v.Epoch)
 
 	// Field (1) 'ValidatorIndex'
-	dst = ssz.MarshalUint64(dst, v.ValidatorIndex)
+	dst = ssz.MarshalUint(dst, v.ValidatorIndex)
 
 	return
 }
@@ -1352,7 +1352,7 @@ func (e *Eth1Block) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
 
 	// Field (0) 'Timestamp'
-	dst = ssz.MarshalUint64(dst, e.Timestamp)
+	dst = ssz.MarshalUint(dst, e.Timestamp)
 
 	// Field (1) 'DepositRoot'
 	if size := len(e.DepositRoot); size != 32 {
@@ -1362,7 +1362,7 @@ func (e *Eth1Block) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, e.DepositRoot...)
 
 	// Field (2) 'DepositCount'
-	dst = ssz.MarshalUint64(dst, e.DepositCount)
+	dst = ssz.MarshalUint(dst, e.DepositCount)
 
 	return
 }
@@ -1439,7 +1439,7 @@ func (e *Eth1Data) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, e.DepositRoot...)
 
 	// Field (1) 'DepositCount'
-	dst = ssz.MarshalUint64(dst, e.DepositCount)
+	dst = ssz.MarshalUint(dst, e.DepositCount)
 
 	// Field (2) 'BlockHash'
 	if size := len(e.BlockHash); size != 32 {
@@ -1919,7 +1919,7 @@ func (b *BeaconState) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset := int(10325)
 
 	// Field (0) 'GenesisTime'
-	dst = ssz.MarshalUint64(dst, b.GenesisTime)
+	dst = ssz.MarshalUint(dst, b.GenesisTime)
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if size := len(b.GenesisValidatorsRoot); size != 32 {
@@ -1929,7 +1929,7 @@ func (b *BeaconState) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, b.GenesisValidatorsRoot...)
 
 	// Field (2) 'Slot'
-	dst = ssz.MarshalUint64(dst, b.Slot)
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (3) 'Fork'
 	if b.Fork == nil {
@@ -1978,7 +1978,7 @@ func (b *BeaconState) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset += len(b.Eth1DataVotes) * 72
 
 	// Field (10) 'Eth1DepositIndex'
-	dst = ssz.MarshalUint64(dst, b.Eth1DepositIndex)
+	dst = ssz.MarshalUint(dst, b.Eth1DepositIndex)
 
 	// Offset (11) 'Validators'
 	dst = ssz.WriteOffset(dst, offset)
@@ -2007,7 +2007,7 @@ func (b *BeaconState) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < 64; ii++ {
-		dst = ssz.MarshalUint64(dst, b.Slashings[ii])
+		dst = ssz.MarshalUint(dst, b.Slashings[ii])
 	}
 
 	// Offset (15) 'PreviousEpochParticipation'
@@ -2106,7 +2106,7 @@ func (b *BeaconState) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < len(b.Balances); ii++ {
-		dst = ssz.MarshalUint64(dst, b.Balances[ii])
+		dst = ssz.MarshalUint(dst, b.Balances[ii])
 	}
 
 	// Field (15) 'PreviousEpochParticipation'
@@ -2115,7 +2115,7 @@ func (b *BeaconState) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < len(b.PreviousEpochParticipation); ii++ {
-		dst = ssz.MarshalUint8(dst, b.PreviousEpochParticipation[ii])
+		dst = ssz.MarshalUint(dst, b.PreviousEpochParticipation[ii])
 	}
 
 	// Field (16) 'CurrentEpochParticipation'
@@ -2124,7 +2124,7 @@ func (b *BeaconState) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < len(b.CurrentEpochParticipation); ii++ {
-		dst = ssz.MarshalUint8(dst, b.CurrentEpochParticipation[ii])
+		dst = ssz.MarshalUint(dst, b.CurrentEpochParticipation[ii])
 	}
 
 	// Field (21) 'InactivityScores'
@@ -2133,7 +2133,7 @@ func (b *BeaconState) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 		return
 	}
 	for ii := 0; ii < len(b.InactivityScores); ii++ {
-		dst = ssz.MarshalUint64(dst, b.InactivityScores[ii])
+		dst = ssz.MarshalUint(dst, b.InactivityScores[ii])
 	}
 
 	return
@@ -2682,10 +2682,10 @@ func (b *BeaconBlock) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset := int(84)
 
 	// Field (0) 'Slot'
-	dst = ssz.MarshalUint64(dst, b.Slot)
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	dst = ssz.MarshalUint64(dst, b.ProposerIndex)
+	dst = ssz.MarshalUint(dst, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -2937,19 +2937,19 @@ func (t *Transfer) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
 
 	// Field (0) 'Sender'
-	dst = ssz.MarshalUint64(dst, t.Sender)
+	dst = ssz.MarshalUint(dst, t.Sender)
 
 	// Field (1) 'Recipient'
-	dst = ssz.MarshalUint64(dst, t.Recipient)
+	dst = ssz.MarshalUint(dst, t.Recipient)
 
 	// Field (2) 'Amount'
-	dst = ssz.MarshalUint64(dst, t.Amount)
+	dst = ssz.MarshalUint(dst, t.Amount)
 
 	// Field (3) 'Fee'
-	dst = ssz.MarshalUint64(dst, t.Fee)
+	dst = ssz.MarshalUint(dst, t.Fee)
 
 	// Field (4) 'Slot'
-	dst = ssz.MarshalUint64(dst, t.Slot)
+	dst = ssz.MarshalUint(dst, t.Slot)
 
 	// Field (5) 'Pubkey'
 	if size := len(t.Pubkey); size != 48 {
@@ -3587,10 +3587,10 @@ func (b *BeaconBlockHeader) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
 
 	// Field (0) 'Slot'
-	dst = ssz.MarshalUint64(dst, b.Slot)
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	dst = ssz.MarshalUint64(dst, b.ProposerIndex)
+	dst = ssz.MarshalUint(dst, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -4723,10 +4723,10 @@ func (b *BeaconBlockMinimal) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	offset := int(84)
 
 	// Field (0) 'Slot'
-	dst = ssz.MarshalUint64(dst, b.Slot)
+	dst = ssz.MarshalUint(dst, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	dst = ssz.MarshalUint64(dst, b.ProposerIndex)
+	dst = ssz.MarshalUint(dst, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {

--- a/spectests/structs_encoding.go
+++ b/spectests/structs_encoding.go
@@ -832,7 +832,7 @@ func (i *IndexedAttestation) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range i.AttestationIndices {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 
@@ -2549,7 +2549,7 @@ func (b *BeaconState) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.Balances {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 
@@ -2582,7 +2582,7 @@ func (b *BeaconState) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.Slashings {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.Merkleize(subIndx)
 	}
@@ -2595,7 +2595,7 @@ func (b *BeaconState) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.PreviousEpochParticipation {
-			hh.AppendUint8(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 
@@ -2611,7 +2611,7 @@ func (b *BeaconState) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.CurrentEpochParticipation {
-			hh.AppendUint8(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 
@@ -2649,7 +2649,7 @@ func (b *BeaconState) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 		}
 		subIndx := hh.Index()
 		for _, i := range b.InactivityScores {
-			hh.AppendUint64(i)
+			ssz.AppendUint(hh, i)
 		}
 		hh.FillUpTo32()
 

--- a/spectests/structs_encoding.go
+++ b/spectests/structs_encoding.go
@@ -105,7 +105,7 @@ func (a *AggregateAndProof) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Index'
-	hh.PutUint64(a.Index)
+	ssz.PutUint(hh, a.Index)
 
 	// Field (1) 'Aggregate'
 	if err = a.Aggregate.HashTreeRootWith(hh); err != nil {
@@ -179,7 +179,7 @@ func (c *Checkpoint) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Epoch'
-	hh.PutUint64(uint64(c.Epoch))
+	ssz.PutUint(hh, c.Epoch)
 
 	// Field (1) 'Root'
 	if size := len(c.Root); size != 32 {
@@ -281,10 +281,10 @@ func (a *AttestationData) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Slot'
-	hh.PutUint64(uint64(a.Slot))
+	ssz.PutUint(hh, a.Slot)
 
 	// Field (1) 'Index'
-	hh.PutUint64(a.Index)
+	ssz.PutUint(hh, a.Index)
 
 	// Field (2) 'BeaconBlockHash'
 	hh.PutBytes(a.BeaconBlockHash[:])
@@ -509,7 +509,7 @@ func (d *DepositData) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(d.WithdrawalCredentials[:])
 
 	// Field (2) 'Amount'
-	hh.PutUint64(d.Amount)
+	ssz.PutUint(hh, d.Amount)
 
 	// Field (3) 'Signature'
 	if size := len(d.Signature); size != 96 {
@@ -709,7 +709,7 @@ func (d *DepositMessage) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(d.WithdrawalCredentials)
 
 	// Field (2) 'Amount'
-	hh.PutUint64(d.Amount)
+	ssz.PutUint(hh, d.Amount)
 
 	hh.Merkleize(indx)
 	return
@@ -974,10 +974,10 @@ func (p *PendingAttestation) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 
 	// Field (2) 'InclusionDelay'
-	hh.PutUint64(p.InclusionDelay)
+	ssz.PutUint(hh, p.InclusionDelay)
 
 	// Field (3) 'ProposerIndex'
-	hh.PutUint64(p.ProposerIndex)
+	ssz.PutUint(hh, p.ProposerIndex)
 
 	hh.Merkleize(indx)
 	return
@@ -1068,7 +1068,7 @@ func (f *Fork) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(f.CurrentVersion)
 
 	// Field (2) 'Epoch'
-	hh.PutUint64(f.Epoch)
+	ssz.PutUint(hh, f.Epoch)
 
 	hh.Merkleize(indx)
 	return
@@ -1189,22 +1189,22 @@ func (v *Validator) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(v.WithdrawalCredentials)
 
 	// Field (2) 'EffectiveBalance'
-	hh.PutUint64(v.EffectiveBalance)
+	ssz.PutUint(hh, v.EffectiveBalance)
 
 	// Field (3) 'Slashed'
 	hh.PutBool(v.Slashed)
 
 	// Field (4) 'ActivationEligibilityEpoch'
-	hh.PutUint64(v.ActivationEligibilityEpoch)
+	ssz.PutUint(hh, v.ActivationEligibilityEpoch)
 
 	// Field (5) 'ActivationEpoch'
-	hh.PutUint64(v.ActivationEpoch)
+	ssz.PutUint(hh, v.ActivationEpoch)
 
 	// Field (6) 'ExitEpoch'
-	hh.PutUint64(v.ExitEpoch)
+	ssz.PutUint(hh, v.ExitEpoch)
 
 	// Field (7) 'WithdrawableEpoch'
-	hh.PutUint64(v.WithdrawableEpoch)
+	ssz.PutUint(hh, v.WithdrawableEpoch)
 
 	hh.Merkleize(indx)
 	return
@@ -1261,10 +1261,10 @@ func (v *VoluntaryExit) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Epoch'
-	hh.PutUint64(v.Epoch)
+	ssz.PutUint(hh, v.Epoch)
 
 	// Field (1) 'ValidatorIndex'
-	hh.PutUint64(v.ValidatorIndex)
+	ssz.PutUint(hh, v.ValidatorIndex)
 
 	hh.Merkleize(indx)
 	return
@@ -1406,7 +1406,7 @@ func (e *Eth1Block) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Timestamp'
-	hh.PutUint64(e.Timestamp)
+	ssz.PutUint(hh, e.Timestamp)
 
 	// Field (1) 'DepositRoot'
 	if size := len(e.DepositRoot); size != 32 {
@@ -1416,7 +1416,7 @@ func (e *Eth1Block) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(e.DepositRoot)
 
 	// Field (2) 'DepositCount'
-	hh.PutUint64(e.DepositCount)
+	ssz.PutUint(hh, e.DepositCount)
 
 	hh.Merkleize(indx)
 	return
@@ -1500,7 +1500,7 @@ func (e *Eth1Data) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(e.DepositRoot)
 
 	// Field (1) 'DepositCount'
-	hh.PutUint64(e.DepositCount)
+	ssz.PutUint(hh, e.DepositCount)
 
 	// Field (2) 'BlockHash'
 	if size := len(e.BlockHash); size != 32 {
@@ -2442,7 +2442,7 @@ func (b *BeaconState) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'GenesisTime'
-	hh.PutUint64(b.GenesisTime)
+	ssz.PutUint(hh, b.GenesisTime)
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if size := len(b.GenesisValidatorsRoot); size != 32 {
@@ -2452,7 +2452,7 @@ func (b *BeaconState) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(b.GenesisValidatorsRoot)
 
 	// Field (2) 'Slot'
-	hh.PutUint64(b.Slot)
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (3) 'Fork'
 	if err = b.Fork.HashTreeRootWith(hh); err != nil {
@@ -2523,7 +2523,7 @@ func (b *BeaconState) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 
 	// Field (10) 'Eth1DepositIndex'
-	hh.PutUint64(b.Eth1DepositIndex)
+	ssz.PutUint(hh, b.Eth1DepositIndex)
 
 	// Field (11) 'Validators'
 	{
@@ -2790,10 +2790,10 @@ func (b *BeaconBlock) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Slot'
-	hh.PutUint64(b.Slot)
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	hh.PutUint64(b.ProposerIndex)
+	ssz.PutUint(hh, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -3022,19 +3022,19 @@ func (t *Transfer) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Sender'
-	hh.PutUint64(t.Sender)
+	ssz.PutUint(hh, t.Sender)
 
 	// Field (1) 'Recipient'
-	hh.PutUint64(t.Recipient)
+	ssz.PutUint(hh, t.Recipient)
 
 	// Field (2) 'Amount'
-	hh.PutUint64(t.Amount)
+	ssz.PutUint(hh, t.Amount)
 
 	// Field (3) 'Fee'
-	hh.PutUint64(t.Fee)
+	ssz.PutUint(hh, t.Fee)
 
 	// Field (4) 'Slot'
-	hh.PutUint64(t.Slot)
+	ssz.PutUint(hh, t.Slot)
 
 	// Field (5) 'Pubkey'
 	if size := len(t.Pubkey); size != 48 {
@@ -3667,10 +3667,10 @@ func (b *BeaconBlockHeader) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Slot'
-	hh.PutUint64(b.Slot)
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	hh.PutUint64(b.ProposerIndex)
+	ssz.PutUint(hh, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {
@@ -4831,10 +4831,10 @@ func (b *BeaconBlockMinimal) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Slot'
-	hh.PutUint64(b.Slot)
+	ssz.PutUint(hh, b.Slot)
 
 	// Field (1) 'ProposerIndex'
-	hh.PutUint64(b.ProposerIndex)
+	ssz.PutUint(hh, b.ProposerIndex)
 
 	// Field (2) 'ParentRoot'
 	if size := len(b.ParentRoot); size != 32 {

--- a/spectests/structs_encoding.go
+++ b/spectests/structs_encoding.go
@@ -797,7 +797,7 @@ func (i *IndexedAttestation) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		i.AttestationIndices = ssz.ExtendUint64(i.AttestationIndices, num)
+		i.AttestationIndices = ssz.ExtendUint(i.AttestationIndices, num)
 		for ii := 0; ii < num; ii++ {
 			i.AttestationIndices[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
 		}
@@ -2235,7 +2235,7 @@ func (b *BeaconState) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (14) 'Slashings'
-	b.Slashings = ssz.ExtendUint64(b.Slashings, 64)
+	b.Slashings = ssz.ExtendUint(b.Slashings, 64)
 	for ii := 0; ii < 64; ii++ {
 		b.Slashings[ii] = ssz.UnmarshallUint64(buf[6416:6928][ii*8 : (ii+1)*8])
 	}
@@ -2357,7 +2357,7 @@ func (b *BeaconState) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		b.Balances = ssz.ExtendUint64(b.Balances, num)
+		b.Balances = ssz.ExtendUint(b.Balances, num)
 		for ii := 0; ii < num; ii++ {
 			b.Balances[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
 		}
@@ -2370,7 +2370,7 @@ func (b *BeaconState) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		b.PreviousEpochParticipation = ssz.ExtendUint8(b.PreviousEpochParticipation, num)
+		b.PreviousEpochParticipation = ssz.ExtendUint(b.PreviousEpochParticipation, num)
 		for ii := 0; ii < num; ii++ {
 			b.PreviousEpochParticipation[ii] = ssz.UnmarshallUint8(buf[ii*1 : (ii+1)*1])
 		}
@@ -2383,7 +2383,7 @@ func (b *BeaconState) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		b.CurrentEpochParticipation = ssz.ExtendUint8(b.CurrentEpochParticipation, num)
+		b.CurrentEpochParticipation = ssz.ExtendUint(b.CurrentEpochParticipation, num)
 		for ii := 0; ii < num; ii++ {
 			b.CurrentEpochParticipation[ii] = ssz.UnmarshallUint8(buf[ii*1 : (ii+1)*1])
 		}
@@ -2396,7 +2396,7 @@ func (b *BeaconState) UnmarshalSSZ(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		b.InactivityScores = ssz.ExtendUint64(b.InactivityScores, num)
+		b.InactivityScores = ssz.ExtendUint(b.InactivityScores, num)
 		for ii := 0; ii < num; ii++ {
 			b.InactivityScores[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
 		}

--- a/spectests/structs_encoding.go
+++ b/spectests/structs_encoding.go
@@ -53,7 +53,7 @@ func (a *AggregateAndProof) UnmarshalSSZ(buf []byte) error {
 	var o1 uint64
 
 	// Field (0) 'Index'
-	a.Index = ssz.UnmarshallUint64(buf[0:8])
+	a.Index = ssz.UnmarshallUint[uint64](buf[0:8])
 
 	// Offset (1) 'Aggregate'
 	if o1 = ssz.ReadOffset(buf[8:12]); o1 > size {
@@ -152,7 +152,7 @@ func (c *Checkpoint) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Epoch'
-	c.Epoch = external2.EpochAlias(ssz.UnmarshallUint64(buf[0:8]))
+	c.Epoch = ssz.UnmarshallUint[external2.EpochAlias](buf[0:8])
 
 	// Field (1) 'Root'
 	if cap(c.Root) == 0 {
@@ -238,10 +238,10 @@ func (a *AttestationData) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Slot'
-	a.Slot = Slot(ssz.UnmarshallUint64(buf[0:8]))
+	a.Slot = ssz.UnmarshallUint[Slot](buf[0:8])
 
 	// Field (1) 'Index'
-	a.Index = ssz.UnmarshallUint64(buf[8:16])
+	a.Index = ssz.UnmarshallUint[uint64](buf[8:16])
 
 	// Field (2) 'BeaconBlockHash'
 	copy(a.BeaconBlockHash[:], buf[16:48])
@@ -476,7 +476,7 @@ func (d *DepositData) UnmarshalSSZ(buf []byte) error {
 	copy(d.WithdrawalCredentials[:], buf[48:80])
 
 	// Field (2) 'Amount'
-	d.Amount = ssz.UnmarshallUint64(buf[80:88])
+	d.Amount = ssz.UnmarshallUint[uint64](buf[80:88])
 
 	// Field (3) 'Signature'
 	if cap(d.Signature) == 0 {
@@ -674,7 +674,7 @@ func (d *DepositMessage) UnmarshalSSZ(buf []byte) error {
 	d.WithdrawalCredentials = append(d.WithdrawalCredentials, buf[48:80]...)
 
 	// Field (2) 'Amount'
-	d.Amount = ssz.UnmarshallUint64(buf[80:88])
+	d.Amount = ssz.UnmarshallUint[uint64](buf[80:88])
 
 	return err
 }
@@ -799,7 +799,7 @@ func (i *IndexedAttestation) UnmarshalSSZ(buf []byte) error {
 		}
 		i.AttestationIndices = ssz.ExtendUint(i.AttestationIndices, num)
 		for ii := 0; ii < num; ii++ {
-			i.AttestationIndices[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
+			i.AttestationIndices[ii] = ssz.UnmarshallUint[uint64](buf[ii*8 : (ii+1)*8])
 		}
 	}
 	return err
@@ -923,10 +923,10 @@ func (p *PendingAttestation) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (2) 'InclusionDelay'
-	p.InclusionDelay = ssz.UnmarshallUint64(buf[132:140])
+	p.InclusionDelay = ssz.UnmarshallUint[uint64](buf[132:140])
 
 	// Field (3) 'ProposerIndex'
-	p.ProposerIndex = ssz.UnmarshallUint64(buf[140:148])
+	p.ProposerIndex = ssz.UnmarshallUint[uint64](buf[140:148])
 
 	// Field (0) 'AggregationBits'
 	{
@@ -1033,7 +1033,7 @@ func (f *Fork) UnmarshalSSZ(buf []byte) error {
 	f.CurrentVersion = append(f.CurrentVersion, buf[4:8]...)
 
 	// Field (2) 'Epoch'
-	f.Epoch = ssz.UnmarshallUint64(buf[8:16])
+	f.Epoch = ssz.UnmarshallUint[uint64](buf[8:16])
 
 	return err
 }
@@ -1139,22 +1139,22 @@ func (v *Validator) UnmarshalSSZ(buf []byte) error {
 	v.WithdrawalCredentials = append(v.WithdrawalCredentials, buf[48:80]...)
 
 	// Field (2) 'EffectiveBalance'
-	v.EffectiveBalance = ssz.UnmarshallUint64(buf[80:88])
+	v.EffectiveBalance = ssz.UnmarshallUint[uint64](buf[80:88])
 
 	// Field (3) 'Slashed'
 	v.Slashed = ssz.UnmarshalBool(buf[88:89])
 
 	// Field (4) 'ActivationEligibilityEpoch'
-	v.ActivationEligibilityEpoch = ssz.UnmarshallUint64(buf[89:97])
+	v.ActivationEligibilityEpoch = ssz.UnmarshallUint[uint64](buf[89:97])
 
 	// Field (5) 'ActivationEpoch'
-	v.ActivationEpoch = ssz.UnmarshallUint64(buf[97:105])
+	v.ActivationEpoch = ssz.UnmarshallUint[uint64](buf[97:105])
 
 	// Field (6) 'ExitEpoch'
-	v.ExitEpoch = ssz.UnmarshallUint64(buf[105:113])
+	v.ExitEpoch = ssz.UnmarshallUint[uint64](buf[105:113])
 
 	// Field (7) 'WithdrawableEpoch'
-	v.WithdrawableEpoch = ssz.UnmarshallUint64(buf[113:121])
+	v.WithdrawableEpoch = ssz.UnmarshallUint[uint64](buf[113:121])
 
 	return err
 }
@@ -1237,10 +1237,10 @@ func (v *VoluntaryExit) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Epoch'
-	v.Epoch = ssz.UnmarshallUint64(buf[0:8])
+	v.Epoch = ssz.UnmarshallUint[uint64](buf[0:8])
 
 	// Field (1) 'ValidatorIndex'
-	v.ValidatorIndex = ssz.UnmarshallUint64(buf[8:16])
+	v.ValidatorIndex = ssz.UnmarshallUint[uint64](buf[8:16])
 
 	return err
 }
@@ -1376,7 +1376,7 @@ func (e *Eth1Block) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Timestamp'
-	e.Timestamp = ssz.UnmarshallUint64(buf[0:8])
+	e.Timestamp = ssz.UnmarshallUint[uint64](buf[0:8])
 
 	// Field (1) 'DepositRoot'
 	if cap(e.DepositRoot) == 0 {
@@ -1385,7 +1385,7 @@ func (e *Eth1Block) UnmarshalSSZ(buf []byte) error {
 	e.DepositRoot = append(e.DepositRoot, buf[8:40]...)
 
 	// Field (2) 'DepositCount'
-	e.DepositCount = ssz.UnmarshallUint64(buf[40:48])
+	e.DepositCount = ssz.UnmarshallUint[uint64](buf[40:48])
 
 	return err
 }
@@ -1466,7 +1466,7 @@ func (e *Eth1Data) UnmarshalSSZ(buf []byte) error {
 	e.DepositRoot = append(e.DepositRoot, buf[0:32]...)
 
 	// Field (1) 'DepositCount'
-	e.DepositCount = ssz.UnmarshallUint64(buf[32:40])
+	e.DepositCount = ssz.UnmarshallUint[uint64](buf[32:40])
 
 	// Field (2) 'BlockHash'
 	if cap(e.BlockHash) == 0 {
@@ -2151,7 +2151,7 @@ func (b *BeaconState) UnmarshalSSZ(buf []byte) error {
 	var o7, o9, o11, o12, o15, o16, o21 uint64
 
 	// Field (0) 'GenesisTime'
-	b.GenesisTime = ssz.UnmarshallUint64(buf[0:8])
+	b.GenesisTime = ssz.UnmarshallUint[uint64](buf[0:8])
 
 	// Field (1) 'GenesisValidatorsRoot'
 	if cap(b.GenesisValidatorsRoot) == 0 {
@@ -2160,7 +2160,7 @@ func (b *BeaconState) UnmarshalSSZ(buf []byte) error {
 	b.GenesisValidatorsRoot = append(b.GenesisValidatorsRoot, buf[8:40]...)
 
 	// Field (2) 'Slot'
-	b.Slot = ssz.UnmarshallUint64(buf[40:48])
+	b.Slot = ssz.UnmarshallUint[uint64](buf[40:48])
 
 	// Field (3) 'Fork'
 	if b.Fork == nil {
@@ -2213,7 +2213,7 @@ func (b *BeaconState) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (10) 'Eth1DepositIndex'
-	b.Eth1DepositIndex = ssz.UnmarshallUint64(buf[4352:4360])
+	b.Eth1DepositIndex = ssz.UnmarshallUint[uint64](buf[4352:4360])
 
 	// Offset (11) 'Validators'
 	if o11 = ssz.ReadOffset(buf[4360:4364]); o11 > size || o9 > o11 {
@@ -2237,7 +2237,7 @@ func (b *BeaconState) UnmarshalSSZ(buf []byte) error {
 	// Field (14) 'Slashings'
 	b.Slashings = ssz.ExtendUint(b.Slashings, 64)
 	for ii := 0; ii < 64; ii++ {
-		b.Slashings[ii] = ssz.UnmarshallUint64(buf[6416:6928][ii*8 : (ii+1)*8])
+		b.Slashings[ii] = ssz.UnmarshallUint[uint64](buf[6416:6928][ii*8 : (ii+1)*8])
 	}
 
 	// Offset (15) 'PreviousEpochParticipation'
@@ -2359,7 +2359,7 @@ func (b *BeaconState) UnmarshalSSZ(buf []byte) error {
 		}
 		b.Balances = ssz.ExtendUint(b.Balances, num)
 		for ii := 0; ii < num; ii++ {
-			b.Balances[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
+			b.Balances[ii] = ssz.UnmarshallUint[uint64](buf[ii*8 : (ii+1)*8])
 		}
 	}
 
@@ -2372,7 +2372,7 @@ func (b *BeaconState) UnmarshalSSZ(buf []byte) error {
 		}
 		b.PreviousEpochParticipation = ssz.ExtendUint(b.PreviousEpochParticipation, num)
 		for ii := 0; ii < num; ii++ {
-			b.PreviousEpochParticipation[ii] = ssz.UnmarshallUint8(buf[ii*1 : (ii+1)*1])
+			b.PreviousEpochParticipation[ii] = ssz.UnmarshallUint[uint8](buf[ii*1 : (ii+1)*1])
 		}
 	}
 
@@ -2385,7 +2385,7 @@ func (b *BeaconState) UnmarshalSSZ(buf []byte) error {
 		}
 		b.CurrentEpochParticipation = ssz.ExtendUint(b.CurrentEpochParticipation, num)
 		for ii := 0; ii < num; ii++ {
-			b.CurrentEpochParticipation[ii] = ssz.UnmarshallUint8(buf[ii*1 : (ii+1)*1])
+			b.CurrentEpochParticipation[ii] = ssz.UnmarshallUint[uint8](buf[ii*1 : (ii+1)*1])
 		}
 	}
 
@@ -2398,7 +2398,7 @@ func (b *BeaconState) UnmarshalSSZ(buf []byte) error {
 		}
 		b.InactivityScores = ssz.ExtendUint(b.InactivityScores, num)
 		for ii := 0; ii < num; ii++ {
-			b.InactivityScores[ii] = ssz.UnmarshallUint64(buf[ii*8 : (ii+1)*8])
+			b.InactivityScores[ii] = ssz.UnmarshallUint[uint64](buf[ii*8 : (ii+1)*8])
 		}
 	}
 	return err
@@ -2728,10 +2728,10 @@ func (b *BeaconBlock) UnmarshalSSZ(buf []byte) error {
 	var o4 uint64
 
 	// Field (0) 'Slot'
-	b.Slot = ssz.UnmarshallUint64(buf[0:8])
+	b.Slot = ssz.UnmarshallUint[uint64](buf[0:8])
 
 	// Field (1) 'ProposerIndex'
-	b.ProposerIndex = ssz.UnmarshallUint64(buf[8:16])
+	b.ProposerIndex = ssz.UnmarshallUint[uint64](buf[8:16])
 
 	// Field (2) 'ParentRoot'
 	if cap(b.ParentRoot) == 0 {
@@ -2977,19 +2977,19 @@ func (t *Transfer) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Sender'
-	t.Sender = ssz.UnmarshallUint64(buf[0:8])
+	t.Sender = ssz.UnmarshallUint[uint64](buf[0:8])
 
 	// Field (1) 'Recipient'
-	t.Recipient = ssz.UnmarshallUint64(buf[8:16])
+	t.Recipient = ssz.UnmarshallUint[uint64](buf[8:16])
 
 	// Field (2) 'Amount'
-	t.Amount = ssz.UnmarshallUint64(buf[16:24])
+	t.Amount = ssz.UnmarshallUint[uint64](buf[16:24])
 
 	// Field (3) 'Fee'
-	t.Fee = ssz.UnmarshallUint64(buf[24:32])
+	t.Fee = ssz.UnmarshallUint[uint64](buf[24:32])
 
 	// Field (4) 'Slot'
-	t.Slot = ssz.UnmarshallUint64(buf[32:40])
+	t.Slot = ssz.UnmarshallUint[uint64](buf[32:40])
 
 	// Field (5) 'Pubkey'
 	if cap(t.Pubkey) == 0 {
@@ -3625,10 +3625,10 @@ func (b *BeaconBlockHeader) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Slot'
-	b.Slot = ssz.UnmarshallUint64(buf[0:8])
+	b.Slot = ssz.UnmarshallUint[uint64](buf[0:8])
 
 	// Field (1) 'ProposerIndex'
-	b.ProposerIndex = ssz.UnmarshallUint64(buf[8:16])
+	b.ProposerIndex = ssz.UnmarshallUint[uint64](buf[8:16])
 
 	// Field (2) 'ParentRoot'
 	if cap(b.ParentRoot) == 0 {
@@ -4769,10 +4769,10 @@ func (b *BeaconBlockMinimal) UnmarshalSSZ(buf []byte) error {
 	var o4 uint64
 
 	// Field (0) 'Slot'
-	b.Slot = ssz.UnmarshallUint64(buf[0:8])
+	b.Slot = ssz.UnmarshallUint[uint64](buf[0:8])
 
 	// Field (1) 'ProposerIndex'
-	b.ProposerIndex = ssz.UnmarshallUint64(buf[8:16])
+	b.ProposerIndex = ssz.UnmarshallUint[uint64](buf[8:16])
 
 	// Field (2) 'ParentRoot'
 	if cap(b.ParentRoot) == 0 {

--- a/spectests/structs_encoding.go
+++ b/spectests/structs_encoding.go
@@ -60,7 +60,7 @@ func (a *AggregateAndProof) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o1 < 108 {
+	if o1 != 108 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -359,7 +359,7 @@ func (a *Attestation) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o0 < 228 {
+	if o0 != 228 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -772,7 +772,7 @@ func (i *IndexedAttestation) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o0 < 228 {
+	if o0 != 228 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -910,7 +910,7 @@ func (p *PendingAttestation) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o0 < 148 {
+	if o0 != 148 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -1142,7 +1142,10 @@ func (v *Validator) UnmarshalSSZ(buf []byte) error {
 	v.EffectiveBalance = ssz.UnmarshallUint[uint64](buf[80:88])
 
 	// Field (3) 'Slashed'
-	v.Slashed = ssz.UnmarshalBool(buf[88:89])
+	v.Slashed, err = ssz.DecodeBool(buf[88:89])
+	if err != nil {
+		return err
+	}
 
 	// Field (4) 'ActivationEligibilityEpoch'
 	v.ActivationEligibilityEpoch = ssz.UnmarshallUint[uint64](buf[89:97])
@@ -1833,7 +1836,7 @@ func (a *AttesterSlashing) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o0 < 8 {
+	if o0 != 8 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -2195,7 +2198,7 @@ func (b *BeaconState) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o7 < 10325 {
+	if o7 != 10325 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -2750,7 +2753,7 @@ func (b *BeaconBlock) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o4 < 84 {
+	if o4 != 84 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -2866,7 +2869,7 @@ func (s *SignedBeaconBlock) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o0 < 100 {
+	if o0 != 100 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -3221,7 +3224,7 @@ func (b *BeaconBlockBody) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o3 < 444 {
+	if o3 != 444 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -3735,7 +3738,7 @@ func (e *ErrorResponse) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o0 < 4 {
+	if o0 != 4 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -4211,7 +4214,7 @@ func (s *SignedBeaconBlockMinimal) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o0 < 100 {
+	if o0 != 100 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -4439,7 +4442,7 @@ func (b *BeaconBlockBodyMinimal) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o3 < 320 {
+	if o3 != 320 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -4791,7 +4794,7 @@ func (b *BeaconBlockMinimal) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o4 < 84 {
+	if o4 != 84 {
 		return ssz.ErrInvalidVariableOffset
 	}
 

--- a/sszgen/generator/hash.go
+++ b/sszgen/generator/hash.go
@@ -1,0 +1,216 @@
+package generator
+
+import (
+	"fmt"
+	"strings"
+)
+
+func (e *env) hashTreeRoot(name string, v *Value) string {
+	tmpl := `// HashTreeRoot ssz hashes the {{.name}} object
+	func (:: *{{.name}}) HashTreeRoot() ([32]byte, error) {
+		return ssz.HashWithDefaultHasher(::)
+	}
+	
+	// HashTreeRootWith ssz hashes the {{.name}} object with a hasher	
+	func (:: *{{.name}}) HashTreeRootWith(hh *ssz.Hasher) (err error) {
+		{{.hashTreeRoot}}
+		return
+	}`
+
+	data := map[string]interface{}{
+		"name":         name,
+		"hashTreeRoot": v.hashTreeRootContainer(true),
+	}
+	str := execTmpl(tmpl, data)
+	return appendObjSignature(str, v)
+}
+
+func (v *Value) hashRoots(isList bool, elem Type) string {
+	subName := "i"
+	if v.e.c {
+		subName += "[:]"
+	}
+	inner := ""
+	if !v.e.c && elem == TypeBytes {
+		inner = fmt.Sprintf(`if len(i) != %d {
+			err = ssz.ErrBytesLength
+			return
+		}
+		`, v.e.s)
+	}
+
+	appendExpr := ""
+	appendFn := ""
+	var elemSize uint64
+	if elem == TypeBytes {
+		if v.e.s != 32 {
+			appendFn = "PutBytes"
+			elemSize = v.e.s
+		} else {
+			appendFn = "Append"
+			elemSize = 32
+		}
+	} else {
+		appendExpr = fmt.Sprintf("ssz.AppendUint(hh, %s)", subName)
+		elemSize = uint64(v.e.fixedSize())
+	}
+	if appendExpr == "" {
+		appendExpr = fmt.Sprintf("hh.%s(%s)", appendFn, subName)
+	}
+
+	merkleize := "hh.Merkleize(subIndx)"
+	if isList {
+		isComplex := v.e.t == TypeBytes
+		tmpl := `
+		numItems := uint64(len(::.{{.name}}))
+		hh.MerkleizeWithMixin(subIndx, numItems, {{if .isComplex}} {{.listSize}} {{ else }} ssz.CalculateLimit({{.listSize}}, numItems, {{.elemSize}}) {{ end }})`
+		merkleize = execTmpl(tmpl, map[string]interface{}{
+			"name":      v.name,
+			"listSize":  v.s,
+			"elemSize":  elemSize,
+			"isComplex": isComplex,
+		})
+		if elem == TypeUint {
+			merkleize = "hh.FillUpTo32()\n" + merkleize
+		}
+	}
+
+	tmpl := `{
+		{{.outer}}subIndx := hh.Index()
+		for _, i := range ::.{{.name}} {
+			{{.inner}}{{.appendExpr}}
+		}
+		{{.merkleize}}
+	}`
+	return execTmpl(tmpl, map[string]interface{}{
+		"outer":      v.validate(),
+		"inner":      inner,
+		"name":       v.name,
+		"appendExpr": appendExpr,
+		"merkleize":  merkleize,
+	})
+}
+
+func (v *Value) hashTreeRoot(name string, appendBytes bool) string {
+	if name == "" {
+		name = "::." + v.name
+	}
+	switch v.t {
+	case TypeContainer, TypeReference:
+		return v.hashTreeRootContainer(false)
+	case TypeBytes:
+		if v.c {
+			name += "[:]"
+		}
+		if v.isFixed() {
+			tmpl := `{{.validate}}hh.PutBytes({{.name}})`
+			return execTmpl(tmpl, map[string]interface{}{
+				"validate": v.validate(),
+				"name":     name,
+			})
+		}
+		hMethod := "PutBytes"
+		if appendBytes {
+			hMethod = "AppendBytes32"
+		}
+		tmpl := `{
+	elemIndx := hh.Index()
+	byteLen := uint64(len({{.name}}))
+	if byteLen > {{.maxLen}} {
+		err = ssz.ErrIncorrectListSize
+		return
+    }
+	hh.{{.hashMethod}}({{.name}})
+	hh.MerkleizeWithMixin(elemIndx, byteLen, ({{.maxLen}}+31)/32)
+}`
+		return execTmpl(tmpl, map[string]interface{}{
+			"hashMethod": hMethod,
+			"name":       name,
+			"maxLen":     v.m,
+		})
+	case TypeUint:
+		return fmt.Sprintf("ssz.PutUint(hh, %s)", name)
+	case TypeBitList:
+		tmpl := `if len({{.name}}) == 0 {
+			err = ssz.ErrEmptyBitlist
+			return
+		}
+		hh.PutBitlist({{.name}}, {{.size}})
+		`
+		return execTmpl(tmpl, map[string]interface{}{
+			"name": name,
+			"size": v.m,
+		})
+	case TypeBool:
+		return fmt.Sprintf("hh.PutBool(%s)", name)
+	case TypeVector:
+		if v.e.t == TypeContainer {
+			tmpl := `{
+				subIndx := hh.Index()
+				for _, elem := range {{.name}} {
+					if err = elem.HashTreeRootWith(hh); err != nil {
+						return
+					}
+				}
+				hh.Merkleize(subIndx)
+			}`
+			return execTmpl(tmpl, map[string]interface{}{
+				"name": name,
+			})
+		}
+		return v.hashRoots(false, v.e.t)
+	case TypeList:
+		if v.e.isFixed() && (v.e.t == TypeUint || v.e.t == TypeBytes) {
+			return v.hashRoots(true, v.e.t)
+		}
+		tmpl := `{
+			subIndx := hh.Index()
+			num := uint64(len({{.name}}))
+			if num > {{.num}} {
+				err = ssz.ErrIncorrectListSize
+				return
+			}
+			for _, elem := range {{.name}} {
+{{.htrCall}}
+			}
+			hh.MerkleizeWithMixin(subIndx, num, {{.num}})
+		}`
+		htrCall := ""
+		if v.e.t == TypeBytes {
+			htrCall = v.e.hashTreeRoot("elem", true)
+		} else {
+			htrCall = execTmpl(`if err = elem.HashTreeRootWith(hh); err != nil {
+	return
+}`,
+				map[string]interface{}{"name": name})
+		}
+		return execTmpl(tmpl, map[string]interface{}{
+			"name":    name,
+			"num":     v.m,
+			"htrCall": htrCall,
+		})
+	default:
+		panic(fmt.Errorf("hash not implemented for type %s", v.t.String()))
+	}
+}
+
+func (v *Value) hashTreeRootContainer(start bool) string {
+	if !start {
+		return fmt.Sprintf("if err = ::.%s.HashTreeRootWith(hh); err != nil {\n return\n}", v.name)
+	}
+
+	out := []string{}
+	for indx, i := range v.o {
+		out = append(out, fmt.Sprintf("// Field (%d) '%s'\n%s\n", indx, i.name, i.hashTreeRoot("", false)))
+	}
+
+	tmpl := `indx := hh.Index()
+
+	{{.fields}}
+	
+	hh.Merkleize(indx)`
+
+	return execTmpl(tmpl, map[string]interface{}{
+		"fields": strings.Join(out, "\n"),
+	})
+}

--- a/sszgen/generator/marshal.go
+++ b/sszgen/generator/marshal.go
@@ -1,0 +1,165 @@
+package generator
+
+import (
+	"fmt"
+	"strings"
+)
+
+func (e *env) marshal(name string, v *Value) string {
+	tmpl := `// MarshalSSZ ssz marshals the {{.name}} object
+	func (:: *{{.name}}) MarshalSSZ() ([]byte, error) {
+		return ssz.MarshalSSZ(::)
+	}
+
+	// MarshalSSZTo ssz marshals the {{.name}} object to a target array	
+	func (:: *{{.name}}) MarshalSSZTo(buf []byte) (dst []byte, err error) {
+		dst = buf
+		{{.offset}}
+		{{.marshal}}
+		return
+	}`
+
+	data := map[string]interface{}{
+		"name":    name,
+		"marshal": v.marshalContainer(true),
+		"offset":  "",
+	}
+	if !v.isFixed() {
+		data["offset"] = fmt.Sprintf("offset := int(%d)\n", v.fixedSize())
+	}
+	str := execTmpl(tmpl, data)
+	return appendObjSignature(str, v)
+}
+
+func (v *Value) marshal() string {
+	switch v.t {
+	case TypeContainer, TypeReference:
+		return v.marshalContainer(false)
+
+	case TypeBytes:
+		name := v.name
+		if v.c {
+			name += "[:]"
+		}
+		tmpl := `{{.validate}}dst = append(dst, ::.{{.name}}...)`
+
+		return execTmpl(tmpl, map[string]interface{}{
+			"validate": v.validate(),
+			"name":     name,
+		})
+
+	case TypeUint:
+		return fmt.Sprintf("dst = ssz.MarshalUint(dst, ::.%s)", v.name)
+
+	case TypeBitList:
+		return fmt.Sprintf("%sdst = append(dst, ::.%s...)", v.validate(), v.name)
+
+	case TypeBool:
+		return fmt.Sprintf("dst = ssz.MarshalBool(dst, ::.%s)", v.name)
+
+	case TypeVector:
+		if v.e.isFixed() {
+			return v.marshalVector()
+		}
+		fallthrough
+
+	case TypeList:
+		return v.marshalList()
+
+	default:
+		panic(fmt.Errorf("marshal not implemented for type %s", v.t.String()))
+	}
+}
+
+func (v *Value) marshalList() string {
+	v.e.name = v.name + "[ii]"
+
+	str := v.validate()
+
+	if v.e.isFixed() {
+		tmpl := `for ii := 0; ii < len(::.{{.name}}); ii++ {
+			{{.dynamic}}
+		}`
+		str += execTmpl(tmpl, map[string]interface{}{
+			"name":    v.name,
+			"dynamic": v.e.marshal(),
+		})
+		return str
+	}
+
+	tmpl := `{
+		offset = 4 * len(::.{{.name}})
+		for ii := 0; ii < len(::.{{.name}}); ii++ {
+			dst = ssz.WriteOffset(dst, offset)
+			{{.size}}
+		}
+	}
+	for ii := 0; ii < len(::.{{.name}}); ii++ {
+		{{.marshal}}
+	}`
+
+	str += execTmpl(tmpl, map[string]interface{}{
+		"name":    v.name,
+		"size":    v.e.size("offset"),
+		"marshal": v.e.marshal(),
+	})
+	return str
+}
+
+func (v *Value) marshalVector() (str string) {
+	v.e.name = fmt.Sprintf("%s[ii]", v.name)
+
+	tmpl := `{{.validate}}for ii := 0; ii < {{.size}}; ii++ {
+		{{.marshal}}
+	}`
+	return execTmpl(tmpl, map[string]interface{}{
+		"validate": v.validate(),
+		"name":     v.name,
+		"size":     v.s,
+		"marshal":  v.e.marshal(),
+	})
+}
+
+func (v *Value) marshalContainer(start bool) string {
+	if !start {
+		tmpl := `{{ if .check }}if ::.{{.name}} == nil {
+			::.{{.name}} = new({{.obj}})
+		}
+		{{ end }}if dst, err = ::.{{.name}}.MarshalSSZTo(dst); err != nil {
+			return
+		}`
+		check := v.isFixed()
+		if v.isListElem() {
+			check = false
+		}
+		if v.noPtr {
+			check = false
+		}
+		return execTmpl(tmpl, map[string]interface{}{
+			"name":  v.name,
+			"obj":   v.objRef(),
+			"check": check,
+		})
+	}
+
+	offset := v.fixedSize()
+	out := []string{}
+
+	for indx, i := range v.o {
+		var str string
+		if i.isFixed() {
+			str = fmt.Sprintf("// Field (%d) '%s'\n%s\n", indx, i.name, i.marshal())
+		} else {
+			str = fmt.Sprintf("// Offset (%d) '%s'\ndst = ssz.WriteOffset(dst, offset)\n%s\n", indx, i.name, i.size("offset"))
+			offset += i.fixedSize()
+		}
+		out = append(out, str)
+	}
+
+	for indx, i := range v.o {
+		if !i.isFixed() {
+			out = append(out, fmt.Sprintf("// Field (%d) '%s'\n%s\n", indx, i.name, i.marshal()))
+		}
+	}
+	return strings.Join(out, "\n")
+}

--- a/sszgen/generator/size.go
+++ b/sszgen/generator/size.go
@@ -1,0 +1,118 @@
+package generator
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func (e *env) size(name string, v *Value) string {
+	tmpl := `// SizeSSZ returns the ssz encoded size in bytes for the {{.name}} object
+	func (:: *{{.name}}) SizeSSZ() (size int) {
+		size = {{.fixed}}{{if .dynamic}}
+
+		{{.dynamic}}
+		{{end}}
+		return
+	}`
+
+	str := execTmpl(tmpl, map[string]interface{}{
+		"name":    name,
+		"fixed":   v.fixedSize(),
+		"dynamic": v.sizeContainer("size", true),
+	})
+	return appendObjSignature(str, v)
+}
+
+func (v *Value) fixedSize() uint64 {
+	switch v.t {
+	case TypeVector:
+		if v.e == nil {
+			panic(fmt.Sprintf("error computing size of empty vector %v for type name=%s", v, v.name))
+		}
+		if v.e.isFixed() {
+			return v.s * v.e.fixedSize()
+		}
+		return v.s * bytesPerLengthOffset
+	case TypeContainer:
+		var fixed uint64
+		for _, f := range v.o {
+			if f.isFixed() {
+				fixed += f.fixedSize()
+			} else {
+				fixed += bytesPerLengthOffset
+			}
+		}
+		return fixed
+	default:
+		if !v.isFixed() {
+			return bytesPerLengthOffset
+		}
+		return v.s
+	}
+}
+
+func (v *Value) sizeContainer(name string, start bool) string {
+	if !start {
+		tmpl := `{{if .check}} if ::.{{.name}} == nil {
+			::.{{.name}} = new({{.obj}})
+		}
+		{{end}} {{ .dst }} += ::.{{.name}}.SizeSSZ()`
+
+		check := true
+		if v.isListElem() {
+			check = false
+		}
+		if v.noPtr {
+			check = false
+		}
+		return execTmpl(tmpl, map[string]interface{}{
+			"name":  v.name,
+			"dst":   name,
+			"obj":   v.objRef(),
+			"check": check,
+		})
+	}
+	out := []string{}
+	for indx, v := range v.o {
+		if !v.isFixed() {
+			out = append(out, fmt.Sprintf("// Field (%d) '%s'\n%s", indx, v.name, v.size(name)))
+		}
+	}
+	return strings.Join(out, "\n\n")
+}
+
+func (v *Value) size(name string) string {
+	if v.isFixed() {
+		if v.t == TypeContainer {
+			return v.sizeContainer(name, false)
+		}
+		if v.fixedSize() == 1 {
+			return name + "++"
+		}
+		return name + " += " + strconv.Itoa(int(v.fixedSize()))
+	}
+
+	switch v.t {
+	case TypeContainer, TypeReference:
+		return v.sizeContainer(name, false)
+	case TypeBitList, TypeBytes:
+		return fmt.Sprintf(name+" += len(::.%s)", v.name)
+	case TypeList, TypeVector:
+		if v.e.isFixed() {
+			return fmt.Sprintf("%s += len(::.%s) * %d", name, v.name, v.e.fixedSize())
+		}
+		v.e.name = v.name + "[ii]"
+		tmpl := `for ii := 0; ii < len(::.{{.name}}); ii++ {
+			{{.size}} += 4
+			{{.dynamic}}
+		}`
+		return execTmpl(tmpl, map[string]interface{}{
+			"name":    v.name,
+			"size":    name,
+			"dynamic": v.e.size(name),
+		})
+	default:
+		panic(fmt.Errorf("size not implemented for type %s", v.t.String()))
+	}
+}

--- a/sszgen/generator/tag_parser.go
+++ b/sszgen/generator/tag_parser.go
@@ -1,0 +1,184 @@
+package generator
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"text/scanner"
+)
+
+type tokenState int
+
+const (
+	tsBegin tokenState = iota
+	tsLabel
+	tsValue
+	tsCloseTick
+)
+
+func GetSSZTags(tag string) (map[string]string, error) {
+	var lastErr error
+	accumulateError := func(_ *scanner.Scanner, msg string) {
+		lastErr = errors.New(msg)
+	}
+
+	sr := strings.NewReader(tag)
+	sc := scanner.Scanner{}
+	sc.Init(sr)
+	sc.Filename = "tag"
+	sc.Mode ^= scanner.ScanRawStrings
+	sc.Error = accumulateError
+
+	var labelStr string
+	var state tokenState
+	tags := make(map[string]string)
+	for tok := sc.Scan(); tok != scanner.EOF; tok = sc.Scan() {
+		if lastErr != nil {
+			return nil, fmt.Errorf("GetSSZTags failed: token scanner error = %s", lastErr)
+		}
+		if state == tsCloseTick {
+			return nil, errors.New("GetSSZTags failed: undefined behavior when scanning beyond the end of the tag")
+		}
+		txt := sc.TokenText()
+		switch txt {
+		case "`":
+			if state == tsLabel {
+				state = tsCloseTick
+				continue
+			}
+			if state == tsBegin {
+				state = tsLabel
+				continue
+			}
+		case ":":
+			if state == tsLabel {
+				state = tsValue
+				continue
+			}
+		case "\"":
+			continue
+		default:
+			if state == tsValue {
+				tags[labelStr] = trimTagQuotes(txt)
+				state = tsLabel
+				labelStr = ""
+				continue
+			}
+			if state == tsLabel {
+				labelStr += txt
+				continue
+			}
+		}
+	}
+	return tags, nil
+}
+
+var nilInt *int
+
+func isBitList(tags map[string]string) bool {
+	for k, v := range tags {
+		if k == "ssz" {
+			parts := strings.Split(v, ",")
+			for _, p := range parts {
+				if p == "bitlist" {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func extractSSZDimensions(tag string) ([]*SSZDimension, error) {
+	tags, err := GetSSZTags(tag)
+	if err != nil {
+		return nil, err
+	}
+	sszSizes, sizeDefined := tags["ssz-size"]
+	sszMax, maxDefined := tags["ssz-max"]
+	if !sizeDefined && !maxDefined {
+		return nil, fmt.Errorf("No ssz-size or ssz-max tags found for element. tag=%s", tag)
+	}
+
+	sizeSplit := strings.Split(sszSizes, ",")
+	maxSplit := strings.Split(sszMax, ",")
+	ndims := len(sizeSplit)
+	if len(maxSplit) > len(sizeSplit) {
+		ndims = len(maxSplit)
+	}
+	dims := make([]*SSZDimension, ndims)
+	for i := 0; i < ndims; i++ {
+		isbl := i == ndims-1 && isBitList(tags)
+		var szi, mxi string
+		if len(sizeSplit) > i {
+			szi = sizeSplit[i]
+		}
+		if len(maxSplit) > i {
+			mxi = maxSplit[i]
+		}
+		if szi == "?" && mxi == "?" {
+			return nil, fmt.Errorf("At dimension %d both ssz-size and ssz-max had a '?' value. For each dimension, either ssz-size or ssz-max must have a value. Ex: 'ssz-size:\"?,32\" ssz-max:\"100\" defines a List with 100 element limit, containing 32 byte fixed-sized vectors. tag=%s", i, tag)
+		}
+		switch szi {
+		case "?", "":
+			if mxi == "?" || mxi == "" {
+				return nil, fmt.Errorf("no numeric ssz-size or ssz-max tag for value at dimesion %d, tag=%s", i, tag)
+			}
+			m, err := strconv.Atoi(mxi)
+			if err != nil {
+				return nil, fmt.Errorf("atoi failed on value %s for ssz-max at dimension %d, tag=%s. err=%s", mxi, i, tag, err)
+			}
+			dims[i] = &SSZDimension{isBitlist: isbl, ListLength: &m}
+		default:
+			s, err := strconv.Atoi(szi)
+			if err != nil {
+				return nil, fmt.Errorf("atoi failed on value %s for ssz-size at dimension %d, tag=%s. err=%s", szi, i, tag, err)
+			}
+			dims[i] = &SSZDimension{isBitlist: isbl, VectorLength: &s}
+		}
+	}
+	return dims, nil
+}
+
+type SSZDimension struct {
+	VectorLength *int
+	ListLength   *int
+	isBitlist    bool
+}
+
+func (dim *SSZDimension) IsVector() bool  { return dim.VectorLength != nilInt }
+func (dim *SSZDimension) IsList() bool    { return dim.ListLength != nilInt }
+func (dim *SSZDimension) IsBitlist() bool { return dim.isBitlist }
+func (dim *SSZDimension) ListLen() int    { return *dim.ListLength }
+func (dim *SSZDimension) VectorLen() int  { return *dim.VectorLength }
+
+func (dim *SSZDimension) ValueType() Type {
+	if dim.IsVector() {
+		return TypeVector
+	}
+	if dim.IsList() {
+		return TypeList
+	}
+	return TypeUndefined
+}
+
+func (dim *SSZDimension) ValueLen() uint64 {
+	if dim.IsList() {
+		return uint64(dim.ListLen())
+	}
+	if dim.IsVector() {
+		return uint64(dim.VectorLen())
+	}
+	return 0
+}
+
+func trimTagQuotes(s string) string {
+	if len(s) > 0 && s[0] == '"' {
+		s = s[1:]
+	}
+	if len(s) > 0 && s[len(s)-1] == '"' {
+		s = s[:len(s)-1]
+	}
+	return s
+}

--- a/sszgen/generator/tree.go
+++ b/sszgen/generator/tree.go
@@ -1,0 +1,153 @@
+package generator
+
+import (
+	"fmt"
+	"strings"
+)
+
+func (e *env) getTree(name string, v *Value) string {
+	tmpl := `// GetTree returns tree-backing for the {{.name}} object
+	func (:: *{{.name}}) GetTreeWithWrapper(w *ssz.Wrapper) (err error) {
+		{{.getTree}}
+		return nil
+	}
+
+	func (:: *{{.name}}) GetTree() (*ssz.Node, error) {
+		w := &ssz.Wrapper{}
+		if err := ::.GetTreeWithWrapper(w); err != nil {
+			return nil, err
+		}
+		return w.Node(), nil
+	}`
+
+	data := map[string]interface{}{
+		"name":    name,
+		"getTree": v.getTreeContainer(true),
+	}
+	str := execTmpl(tmpl, data)
+	return appendObjSignature(str, v)
+}
+
+func (v *Value) getTrees(isList bool, elem Type) string {
+	if elem != TypeUint {
+		panic("unimplemented")
+	}
+
+	subLeaves := execTmpl(`subLeaves := ssz.LeavesFromUint64(::.{{.name}})`, map[string]interface{}{
+		"name": v.name,
+	})
+
+	merkleize := "tmp = ssz.TreeFromNodes(subLeaves)"
+	if isList {
+		tmpl := `numItems := len(::.{{.name}})
+		tmp, err = ssz.TreeFromNodesWithMixin(subLeaves, numItems, int(ssz.CalculateLimit({{.listSize}}, uint64(numItems), {{.elemSize}})))
+		if err != nil {
+			return nil, err
+		}`
+		merkleize = execTmpl(tmpl, map[string]interface{}{
+			"name":     v.name,
+			"listSize": v.s,
+			"elemSize": 8,
+		})
+	}
+
+	tmpl := `{
+		{{.subLeaves}}
+		{{.merkleize}}
+	}`
+	return execTmpl(tmpl, map[string]interface{}{
+		"subLeaves": subLeaves,
+		"merkleize": merkleize,
+	})
+}
+
+func (v *Value) getTree() string {
+	switch v.t {
+	case TypeContainer, TypeReference:
+		return v.getTreeContainer(false)
+	case TypeBytes:
+		name := v.name
+		if v.c {
+			name += "[:]"
+		}
+		tmpl := `{{.validate}}w.AddBytes(::.{{.name}})`
+		return execTmpl(tmpl, map[string]interface{}{
+			"validate": v.validate(),
+			"name":     name,
+		})
+	case TypeUint:
+		return fmt.Sprintf("ssz.AddUint(w, ::.%s)", v.name)
+	case TypeBitList:
+		panic("unimplemented")
+	case TypeBool:
+		return fmt.Sprintf("tmp = ssz.LeafFromBool(::.%s)", v.name)
+	case TypeVector:
+		return v.getTrees(false, v.e.t)
+	case TypeList:
+		if v.e.isFixed() && (v.e.t == TypeUint || v.e.t == TypeBytes) {
+			return v.getTrees(true, v.e.t)
+		}
+		tmpl := `{
+			subIdx := w.Indx()
+			num := len(::.{{.name}})
+			if num > {{.num}} {
+				err = ssz.ErrIncorrectListSize
+				return err
+			}
+			for i := 0; i < num; i++ {
+				n, err := ::.{{.name}}[i].GetTree()
+				if err != nil {
+					return err
+				}
+				w.AddNode(n)
+			}
+			w.CommitWithMixin(subIdx, num, {{.num}})
+		}`
+		return execTmpl(tmpl, map[string]interface{}{
+			"name": v.name,
+			"num":  v.m,
+		})
+	default:
+		panic(fmt.Errorf("hash not implemented for type %s", v.t.String()))
+	}
+}
+
+func (v *Value) getTreeContainer(start bool) string {
+	if !start {
+		return fmt.Sprintf("if err := ::.%s.GetTreeWithWrapper(w); err != nil {\n return err\n}", v.name)
+	}
+
+	numLeaves := nextPowerOfTwo(uint64(len(v.o)))
+	out := []string{}
+	for indx, i := range v.o {
+		out = append(out, fmt.Sprintf("// Field (%d) '%s'\n%s\n", indx, i.name, i.getTree()))
+	}
+
+	emptyLeaves := ""
+	if numLeaves-uint(len(v.o)) > 0 {
+		emptyLeaves = fmt.Sprintf("for i := 0; i < %d; i++ {\nw.AddEmpty()\n}", numLeaves-uint(len(v.o)))
+	}
+
+	tmpl := `indx := w.Indx()
+
+	{{.fields}}
+	{{.emptyLeaves}}
+	
+	w.Commit(indx)`
+
+	return execTmpl(tmpl, map[string]interface{}{
+		"fields":      strings.Join(out, "\n"),
+		"emptyLeaves": emptyLeaves,
+	})
+}
+
+func nextPowerOfTwo(v uint64) uint {
+	v--
+	v |= v >> 1
+	v |= v >> 2
+	v |= v >> 4
+	v |= v >> 8
+	v |= v >> 16
+	v++
+	return uint(v)
+}

--- a/sszgen/generator/unmarshal.go
+++ b/sszgen/generator/unmarshal.go
@@ -1,0 +1,305 @@
+package generator
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func (e *env) unmarshal(name string, v *Value) string {
+	tmpl := `// UnmarshalSSZ ssz unmarshals the {{.name}} object
+	func (:: *{{.name}}) UnmarshalSSZ(buf []byte) error {
+		var err error
+		{{.unmarshal}}
+		return err
+	}`
+
+	str := execTmpl(tmpl, map[string]interface{}{
+		"name":      name,
+		"unmarshal": v.umarshalContainer(true, "buf"),
+	})
+
+	return appendObjSignature(str, v)
+}
+
+func (v *Value) unmarshal(dst string) string {
+	switch v.t {
+	case TypeContainer, TypeReference:
+		return v.umarshalContainer(false, dst)
+
+	case TypeBytes:
+		if v.c {
+			return fmt.Sprintf("copy(::.%s[:], %s)", v.name, dst)
+		}
+		validate := ""
+		if !v.isFixed() {
+			validate = fmt.Sprintf("if len(%s) > %d { return ssz.ErrBytesLength }\n", dst, v.m)
+		}
+		tmpl := `{{.validate}}if cap(::.{{.name}}) == 0 {
+			::.{{.name}} = make([]byte, 0, len({{.dst}}))
+		}
+		::.{{.name}} = append(::.{{.name}}, {{.dst}}...)`
+		return execTmpl(tmpl, map[string]interface{}{
+			"validate": validate,
+			"name":     v.name,
+			"dst":      dst,
+		})
+
+	case TypeUint:
+		if v.ref != "" {
+			return fmt.Sprintf("::.%s = ssz.UnmarshallUint[%s.%s](%s)", v.name, v.ref, v.obj, dst)
+		}
+		if v.obj != "" {
+			return fmt.Sprintf("::.%s = ssz.UnmarshallUint[%s](%s)", v.name, v.obj, dst)
+		}
+		return fmt.Sprintf("::.%s = ssz.UnmarshallUint[%s](%s)", v.name, strings.ToLower(uintVToName(v)), dst)
+
+	case TypeBitList:
+		tmpl := `if err = ssz.ValidateBitlist({{.dst}}, {{.size}}); err != nil {
+			return err
+		}
+		if cap(::.{{.name}}) == 0 {
+			::.{{.name}} = make([]byte, 0, len({{.dst}}))
+		}
+		::.{{.name}} = append(::.{{.name}}, {{.dst}}...)`
+		return execTmpl(tmpl, map[string]interface{}{
+			"name": v.name,
+			"dst":  dst,
+			"size": v.m,
+		})
+
+	case TypeVector:
+		if v.e.isFixed() {
+			dst = fmt.Sprintf("%s[ii*%d: (ii+1)*%d]", dst, v.e.fixedSize(), v.e.fixedSize())
+
+			tmpl := `{{.create}}
+			for ii := 0; ii < {{.size}}; ii++ {
+				{{.unmarshal}}
+			}`
+			return execTmpl(tmpl, map[string]interface{}{
+				"create":    v.createSlice(false),
+				"size":      v.s,
+				"unmarshal": v.e.unmarshal(dst),
+			})
+		}
+		fallthrough
+
+	case TypeList:
+		return v.unmarshalList()
+
+	case TypeBool:
+		return fmt.Sprintf(`::.%s, err = ssz.DecodeBool(%s)
+	    if err != nil {
+		return err
+	}`, v.name, dst)
+
+	default:
+		panic(fmt.Errorf("unmarshal not implemented for type %d", v.t))
+	}
+}
+
+func (v *Value) unmarshalList() string {
+	if v.e.isFixed() {
+		dst := fmt.Sprintf("buf[ii*%d: (ii+1)*%d]", v.e.fixedSize(), v.e.fixedSize())
+
+		tmpl := `num, err := ssz.DivideInt2(len(buf), {{.size}}, {{.max}})
+		if err != nil {
+			return err
+		}
+		{{.create}}
+		for ii := 0; ii < num; ii++ {
+			{{.unmarshal}}
+		}`
+		return execTmpl(tmpl, map[string]interface{}{
+			"size":      v.e.fixedSize(),
+			"max":       v.s,
+			"create":    v.createSlice(true),
+			"unmarshal": v.e.unmarshal(dst),
+		})
+	}
+
+	if v.t == TypeVector {
+		panic("it cannot happen")
+	}
+
+	tmpl := `num, err := ssz.DecodeDynamicLength(buf, {{.max}})
+	if err != nil {
+		return err
+	}
+	{{.create}}
+	err = ssz.UnmarshalDynamic(buf, num, func(indx int, buf []byte) (err error) {
+		{{.unmarshal}}
+		return nil
+	})
+	if err != nil {
+		return err
+	}`
+
+	v.e.name = v.name + "[indx]"
+
+	data := map[string]interface{}{
+		"max":       v.s,
+		"create":    v.createSlice(true),
+		"unmarshal": v.e.unmarshal("buf"),
+	}
+	return execTmpl(tmpl, data)
+}
+
+func (v *Value) umarshalContainer(start bool, dst string) (str string) {
+	if !start {
+		tmpl := `{{ if .check }}if ::.{{.name}} == nil {
+			::.{{.name}} = new({{.obj}})
+		}
+		{{ end }}if err = ::.{{.name}}.UnmarshalSSZ({{.dst}}); err != nil {
+			return err
+		}`
+		check := true
+		if v.noPtr {
+			check = false
+		}
+		return execTmpl(tmpl, map[string]interface{}{
+			"name":  v.name,
+			"obj":   v.objRef(),
+			"dst":   dst,
+			"check": check,
+		})
+	}
+
+	var offsets []string
+	offsetsMatch := map[string]string{}
+
+	for indx, i := range v.o {
+		if !i.isFixed() {
+			name := "o" + strconv.Itoa(indx)
+			if len(offsets) != 0 {
+				offsetsMatch[name] = offsets[len(offsets)-1]
+			}
+			offsets = append(offsets, name)
+		}
+	}
+
+	cmp := "<"
+	if v.isFixed() {
+		cmp = "!="
+	}
+
+	tmpl := `size := uint64(len(buf))
+	if size {{.cmp}} {{.size}} {
+		return ssz.ErrSize
+	}
+	{{if .offsets}}
+		tail := buf
+		var {{.offsets}} uint64
+	{{end}}
+	`
+
+	str += execTmpl(tmpl, map[string]interface{}{
+		"cmp":     cmp,
+		"size":    v.fixedSize(),
+		"offsets": strings.Join(offsets, ", "),
+	})
+
+	var o0 uint64
+	firstOffsetCheck := fmt.Sprintf("%d", v.fixedSize())
+	outs := []string{}
+	for indx, i := range v.o {
+		var incr uint64
+		if i.isFixed() {
+			incr = i.fixedSize()
+		} else {
+			incr = bytesPerLengthOffset
+		}
+
+		dst = fmt.Sprintf("%s[%d:%d]", "buf", o0, o0+incr)
+		o0 += incr
+
+		var res string
+		if i.isFixed() {
+			res = fmt.Sprintf("// Field (%d) '%s'\n%s\n\n", indx, i.name, i.unmarshal(dst))
+		} else {
+			offset := "o" + strconv.Itoa(indx)
+			data := map[string]interface{}{
+				"indx":             indx,
+				"name":             i.name,
+				"offset":           offset,
+				"dst":              dst,
+				"firstOffsetCheck": firstOffsetCheck,
+			}
+			if prev, ok := offsetsMatch[offset]; ok {
+				data["more"] = fmt.Sprintf(" || %s > %s", prev, offset)
+			} else {
+				data["more"] = ""
+			}
+
+			tmpl := `// Offset ({{.indx}}) '{{.name}}'
+			if {{.offset}} = ssz.ReadOffset({{.dst}}); {{.offset}} > size {{.more}} {
+				return ssz.ErrOffset
+			}
+			{{ if .firstOffsetCheck }}
+			if {{.offset}} != {{.firstOffsetCheck}} {
+				return ssz.ErrInvalidVariableOffset
+			}
+			{{ end }}
+			`
+			res = execTmpl(tmpl, data)
+			firstOffsetCheck = ""
+		}
+		outs = append(outs, res)
+	}
+
+	c := 0
+	for indx, i := range v.o {
+		if !i.isFixed() {
+			from := offsets[c]
+			to := ""
+			if c != len(offsets)-1 {
+				to = offsets[c+1]
+			}
+			tmpl := `// Field ({{.indx}}) '{{.name}}'
+			{
+				buf = tail[{{.from}}:{{.to}}]
+				{{.unmarshal}}
+			}`
+			res := execTmpl(tmpl, map[string]interface{}{
+				"indx":      indx,
+				"name":      i.name,
+				"from":      from,
+				"to":        to,
+				"unmarshal": i.unmarshal("buf"),
+			})
+			outs = append(outs, res)
+			c++
+		}
+	}
+
+	str += strings.Join(outs, "\n\n")
+	return
+}
+
+func (v *Value) createSlice(useNumVariable bool) string {
+	if v.t != TypeVector && v.t != TypeList {
+		panic("BUG: create item is only intended to be used with vectors and lists")
+	}
+
+	size := strconv.Itoa(int(v.s))
+	if useNumVariable {
+		size = "num"
+	}
+
+	switch v.e.t {
+	case TypeUint:
+		return fmt.Sprintf("::.%s = ssz.ExtendUint(::.%s, %s)", v.name, v.name, size)
+	case TypeContainer:
+		return fmt.Sprintf("::.%s = make([]*%s, %s)", v.name, v.e.objRef(), size)
+	case TypeBytes:
+		if v.c {
+			return ""
+		}
+		if v.e.c {
+			return fmt.Sprintf("::.%s = make([][%d]byte, %s)", v.name, v.e.s, size)
+		}
+		return fmt.Sprintf("::.%s = make([][]byte, %s)", v.name, size)
+	default:
+		panic(fmt.Sprintf("create not implemented for type %s", v.e.t.String()))
+	}
+}

--- a/sszgen/generator/validate.go
+++ b/sszgen/generator/validate.go
@@ -1,0 +1,53 @@
+package generator
+
+func (v *Value) validate() string {
+	switch v.t {
+	case TypeBitList, TypeBytes:
+		if v.c {
+			return ""
+		}
+		cmp := "!="
+		if !v.isFixed() {
+			cmp = ">"
+		}
+
+		tmpl := `if size := len(::.{{.name}}); size {{.cmp}} {{.size}} {
+			err = ssz.ErrBytesLengthFn("--.{{.name}}", size, {{.size}})
+			return
+		}
+		`
+		return execTmpl(tmpl, map[string]interface{}{
+			"cmp":  cmp,
+			"name": v.name,
+			"size": v.s,
+		})
+
+	case TypeVector:
+		if v.c {
+			return ""
+		}
+		tmpl := `if size := len(::.{{.name}}); size != {{.size}} {
+			err = ssz.ErrVectorLengthFn("--.{{.name}}", size, {{.size}})
+			return
+		}
+		`
+		return execTmpl(tmpl, map[string]interface{}{
+			"name": v.name,
+			"size": v.s,
+		})
+
+	case TypeList:
+		tmpl := `if size := len(::.{{.name}}); size > {{.size}} {
+			err = ssz.ErrListTooBigFn("--.{{.name}}", size, {{.size}})
+			return
+		}
+		`
+		return execTmpl(tmpl, map[string]interface{}{
+			"name": v.name,
+			"size": v.s,
+		})
+
+	default:
+		return ""
+	}
+}

--- a/sszgen/hash.go
+++ b/sszgen/hash.go
@@ -163,11 +163,7 @@ func (v *Value) hashTreeRoot(name string, appendBytes bool) string {
 		}
 
 	case TypeUint:
-		if v.ref != "" || v.obj != "" {
-			name = fmt.Sprintf("%s(%s)", strings.ToLower(uintVToName(v)), name)
-		}
-		bitLen := v.fixedSize() * 8
-		return fmt.Sprintf("hh.PutUint%d(%s)", bitLen, name)
+		return fmt.Sprintf("ssz.PutUint(hh, %s)", name)
 
 	case TypeBitList:
 		tmpl := `if len({{.name}}) == 0 {

--- a/sszgen/hash.go
+++ b/sszgen/hash.go
@@ -42,6 +42,7 @@ func (v *Value) hashRoots(isList bool, elem Type) string {
 	}
 
 	var appendFn string
+	appendExpr := ""
 	var elemSize uint64
 	if elem == TypeBytes {
 		// [][]byte
@@ -56,8 +57,11 @@ func (v *Value) hashRoots(isList bool, elem Type) string {
 		}
 	} else {
 		// []uint64
-		appendFn = "Append" + uintVToName(v.e)
+		appendExpr = fmt.Sprintf("ssz.AppendUint(hh, %s)", subName)
 		elemSize = uint64(v.e.fixedSize())
+	}
+	if appendExpr == "" {
+		appendExpr = fmt.Sprintf("hh.%s(%s)", appendFn, subName)
 	}
 
 	var merkleize string
@@ -93,17 +97,16 @@ func (v *Value) hashRoots(isList bool, elem Type) string {
 	tmpl := `{
 		{{.outer}}subIndx := hh.Index()
 		for _, i := range ::.{{.name}} {
-			{{.inner}}hh.{{.appendFn}}({{.subName}})
+			{{.inner}}{{.appendExpr}}
 		}
 		{{.merkleize}}
 	}`
 	return execTmpl(tmpl, map[string]interface{}{
-		"outer":     v.validate(),
-		"inner":     inner,
-		"name":      v.name,
-		"subName":   subName,
-		"appendFn":  appendFn,
-		"merkleize": merkleize,
+		"outer":      v.validate(),
+		"inner":      inner,
+		"name":       v.name,
+		"appendExpr": appendExpr,
+		"merkleize":  merkleize,
 	})
 }
 
@@ -161,8 +164,7 @@ func (v *Value) hashTreeRoot(name string, appendBytes bool) string {
 
 	case TypeUint:
 		if v.ref != "" || v.obj != "" {
-			// alias to Uint64
-			name = fmt.Sprintf("uint64(%s)", name)
+			name = fmt.Sprintf("%s(%s)", strings.ToLower(uintVToName(v)), name)
 		}
 		bitLen := v.fixedSize() * 8
 		return fmt.Sprintf("hh.PutUint%d(%s)", bitLen, name)

--- a/sszgen/hash_alias_test.go
+++ b/sszgen/hash_alias_test.go
@@ -25,3 +25,20 @@ func TestHashRootsUsesGenericAppendUintForUintAliasElements(t *testing.T) {
 		t.Fatalf("unexpected typed uint append in generated hash roots:\n%s", got)
 	}
 }
+
+func TestHashTreeRootUsesGenericPutUintForUintAlias(t *testing.T) {
+	v := &Value{
+		name: "ValidatorIndex",
+		t:    TypeUint,
+		s:    8,
+		obj:  "ValidatorIndex",
+	}
+
+	got := v.hashTreeRoot("value", false)
+	if !strings.Contains(got, "ssz.PutUint(hh, value)") {
+		t.Fatalf("expected generic uint put in generated hash root, got:\n%s", got)
+	}
+	if strings.Contains(got, "hh.PutUint64(") {
+		t.Fatalf("unexpected typed uint put in generated hash root:\n%s", got)
+	}
+}

--- a/sszgen/hash_alias_test.go
+++ b/sszgen/hash_alias_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHashRootsUsesGenericAppendUintForUintAliasElements(t *testing.T) {
+	v := &Value{
+		name: "ValidatorIndices",
+		t:    TypeVector,
+		s:    512,
+		e: &Value{
+			t:   TypeUint,
+			s:   8,
+			obj: "ValidatorIndex",
+		},
+	}
+
+	got := v.hashRoots(false, v.e.t)
+	if !strings.Contains(got, "ssz.AppendUint(hh, i)") {
+		t.Fatalf("expected generic uint append in generated hash roots, got:\n%s", got)
+	}
+	if strings.Contains(got, "hh.AppendUint64(") {
+		t.Fatalf("unexpected typed uint append in generated hash roots:\n%s", got)
+	}
+}

--- a/sszgen/marshal.go
+++ b/sszgen/marshal.go
@@ -53,14 +53,7 @@ func (v *Value) marshal() string {
 		})
 
 	case TypeUint:
-		var name string
-		if v.ref != "" || v.obj != "" {
-			// alias to Uint64
-			name = fmt.Sprintf("uint64(::.%s)", v.name)
-		} else {
-			name = "::." + v.name
-		}
-		return fmt.Sprintf("dst = ssz.Marshal%s(dst, %s)", uintVToName(v), name)
+		return fmt.Sprintf("dst = ssz.MarshalUint(dst, ::.%s)", v.name)
 
 	case TypeBitList:
 		return fmt.Sprintf("%sdst = append(dst, ::.%s...)", v.validate(), v.name)

--- a/sszgen/marshal_alias_test.go
+++ b/sszgen/marshal_alias_test.go
@@ -1,0 +1,18 @@
+package main
+
+import "testing"
+
+func TestMarshalUsesGenericMarshalUintForUintAlias(t *testing.T) {
+	v := &Value{
+		name: "ValidatorIndex",
+		t:    TypeUint,
+		s:    8,
+		obj:  "ValidatorIndex",
+	}
+
+	got := v.marshal()
+	want := "dst = ssz.MarshalUint(dst, ::.ValidatorIndex)"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}

--- a/sszgen/tree.go
+++ b/sszgen/tree.go
@@ -86,16 +86,7 @@ func (v *Value) getTree() string {
 		})
 
 	case TypeUint:
-		var name string
-		if v.ref != "" || v.obj != "" {
-			// alias to Uint64
-			name = fmt.Sprintf("uint64(::.%s)", v.name)
-		} else {
-			name = "::." + v.name
-		}
-
-		method := uintVToName(v)
-		return fmt.Sprintf("w.Add%s(%s)", method, name)
+		return fmt.Sprintf("ssz.AddUint(w, ::.%s)", v.name)
 
 	case TypeBitList:
 		panic("unimplemented")

--- a/sszgen/tree_alias_test.go
+++ b/sszgen/tree_alias_test.go
@@ -1,0 +1,18 @@
+package main
+
+import "testing"
+
+func TestGetTreeUsesGenericAddUintForUintAlias(t *testing.T) {
+	v := &Value{
+		name: "ValidatorIndex",
+		t:    TypeUint,
+		s:    8,
+		obj:  "ValidatorIndex",
+	}
+
+	got := v.getTree()
+	want := "ssz.AddUint(w, ::.ValidatorIndex)"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}

--- a/sszgen/unmarshal.go
+++ b/sszgen/unmarshal.go
@@ -52,14 +52,12 @@ func (v *Value) unmarshal(dst string) string {
 
 	case TypeUint:
 		if v.ref != "" {
-			// alias, we need to cast the value
-			return fmt.Sprintf("::.%s = %s.%s(ssz.Unmarshall%s(%s))", v.name, v.ref, v.obj, uintVToName(v), dst)
+			return fmt.Sprintf("::.%s = ssz.UnmarshallUint[%s.%s](%s)", v.name, v.ref, v.obj, dst)
 		}
 		if v.obj != "" {
-			// alias to a type on the same package
-			return fmt.Sprintf("::.%s = %s(ssz.Unmarshall%s(%s))", v.name, v.obj, uintVToName(v), dst)
+			return fmt.Sprintf("::.%s = ssz.UnmarshallUint[%s](%s)", v.name, v.obj, dst)
 		}
-		return fmt.Sprintf("::.%s = ssz.Unmarshall%s(%s)", v.name, uintVToName(v), dst)
+		return fmt.Sprintf("::.%s = ssz.UnmarshallUint[%s](%s)", v.name, strings.ToLower(uintVToName(v)), dst)
 
 	case TypeBitList:
 		tmpl := `if err = ssz.ValidateBitlist({{.dst}}, {{.size}}); err != nil {

--- a/sszgen/unmarshal.go
+++ b/sszgen/unmarshal.go
@@ -335,7 +335,7 @@ func (v *Value) createSlice(useNumVariable bool) string {
 	switch v.e.t {
 	case TypeUint:
 		// []int uses the Extend functions in the fastssz package
-		return fmt.Sprintf("::.%s = ssz.Extend%s(::.%s, %s)", v.name, uintVToName(v.e), v.name, size)
+		return fmt.Sprintf("::.%s = ssz.ExtendUint(::.%s, %s)", v.name, v.name, size)
 
 	case TypeContainer:
 		// []*(ref.)Struct{}

--- a/sszgen/unmarshal_alias_test.go
+++ b/sszgen/unmarshal_alias_test.go
@@ -1,0 +1,18 @@
+package main
+
+import "testing"
+
+func TestUnmarshalUsesGenericUnmarshallUintForUintAlias(t *testing.T) {
+	v := &Value{
+		name: "ValidatorIndex",
+		t:    TypeUint,
+		s:    8,
+		obj:  "ValidatorIndex",
+	}
+
+	got := v.unmarshal("buf")
+	want := "::.ValidatorIndex = ssz.UnmarshallUint[ValidatorIndex](buf)"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}

--- a/sszgen/unmarshal_test.go
+++ b/sszgen/unmarshal_test.go
@@ -1,0 +1,20 @@
+package main
+
+import "testing"
+
+func TestCreateSliceUsesGenericExtendUint(t *testing.T) {
+	v := &Value{
+		name: "Field",
+		t:    TypeList,
+		e: &Value{
+			t: TypeUint,
+			s: 8,
+		},
+	}
+
+	got := v.createSlice(true)
+	want := "::.Field = ssz.ExtendUint(::.Field, num)"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}

--- a/tests/codetrie_encoding.go
+++ b/tests/codetrie_encoding.go
@@ -88,7 +88,7 @@ func (m *Metadata) GetTreeWithWrapper(w *ssz.Wrapper) (err error) {
 	indx := w.Indx()
 
 	// Field (0) 'Version'
-	w.AddUint8(m.Version)
+	ssz.AddUint(w, m.Version)
 
 	// Field (1) 'CodeHash'
 	if len(m.CodeHash) != 32 {
@@ -98,7 +98,7 @@ func (m *Metadata) GetTreeWithWrapper(w *ssz.Wrapper) (err error) {
 	w.AddBytes(m.CodeHash)
 
 	// Field (2) 'CodeLength'
-	w.AddUint16(m.CodeLength)
+	ssz.AddUint(w, m.CodeLength)
 
 	for i := 0; i < 1; i++ {
 		w.AddEmpty()
@@ -192,7 +192,7 @@ func (c *Chunk) GetTreeWithWrapper(w *ssz.Wrapper) (err error) {
 	indx := w.Indx()
 
 	// Field (0) 'FIO'
-	w.AddUint8(c.FIO)
+	ssz.AddUint(w, c.FIO)
 
 	// Field (1) 'Code'
 	if len(c.Code) != 32 {

--- a/tests/codetrie_encoding.go
+++ b/tests/codetrie_encoding.go
@@ -37,7 +37,7 @@ func (m *Metadata) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'Version'
-	m.Version = ssz.UnmarshallUint8(buf[0:1])
+	m.Version = ssz.UnmarshallUint[uint8](buf[0:1])
 
 	// Field (1) 'CodeHash'
 	if cap(m.CodeHash) == 0 {
@@ -46,7 +46,7 @@ func (m *Metadata) UnmarshalSSZ(buf []byte) error {
 	m.CodeHash = append(m.CodeHash, buf[1:33]...)
 
 	// Field (2) 'CodeLength'
-	m.CodeLength = ssz.UnmarshallUint16(buf[33:35])
+	m.CodeLength = ssz.UnmarshallUint[uint16](buf[33:35])
 
 	return err
 }
@@ -147,7 +147,7 @@ func (c *Chunk) UnmarshalSSZ(buf []byte) error {
 	}
 
 	// Field (0) 'FIO'
-	c.FIO = ssz.UnmarshallUint8(buf[0:1])
+	c.FIO = ssz.UnmarshallUint[uint8](buf[0:1])
 
 	// Field (1) 'Code'
 	if cap(c.Code) == 0 {

--- a/tests/codetrie_encoding.go
+++ b/tests/codetrie_encoding.go
@@ -67,7 +67,7 @@ func (m *Metadata) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Version'
-	hh.PutUint8(m.Version)
+	ssz.PutUint(hh, m.Version)
 
 	// Field (1) 'CodeHash'
 	if size := len(m.CodeHash); size != 32 {
@@ -77,7 +77,7 @@ func (m *Metadata) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutBytes(m.CodeHash)
 
 	// Field (2) 'CodeLength'
-	hh.PutUint16(m.CodeLength)
+	ssz.PutUint(hh, m.CodeLength)
 
 	hh.Merkleize(indx)
 	return
@@ -174,7 +174,7 @@ func (c *Chunk) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'FIO'
-	hh.PutUint8(c.FIO)
+	ssz.PutUint(hh, c.FIO)
 
 	// Field (1) 'Code'
 	if size := len(c.Code); size != 32 {

--- a/tests/codetrie_encoding.go
+++ b/tests/codetrie_encoding.go
@@ -13,7 +13,7 @@ func (m *Metadata) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
 
 	// Field (0) 'Version'
-	dst = ssz.MarshalUint8(dst, m.Version)
+	dst = ssz.MarshalUint(dst, m.Version)
 
 	// Field (1) 'CodeHash'
 	if size := len(m.CodeHash); size != 32 {
@@ -23,7 +23,7 @@ func (m *Metadata) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = append(dst, m.CodeHash...)
 
 	// Field (2) 'CodeLength'
-	dst = ssz.MarshalUint16(dst, m.CodeLength)
+	dst = ssz.MarshalUint(dst, m.CodeLength)
 
 	return
 }
@@ -126,7 +126,7 @@ func (c *Chunk) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 	dst = buf
 
 	// Field (0) 'FIO'
-	dst = ssz.MarshalUint8(dst, c.FIO)
+	dst = ssz.MarshalUint(dst, c.FIO)
 
 	// Field (1) 'Code'
 	if size := len(c.Code); size != 32 {

--- a/tree.go
+++ b/tree.go
@@ -161,7 +161,7 @@ func TreeFromNodesWithMixin(leaves []*Node, num, limit int) (*Node, error) {
 	}
 
 	// Mixin len
-	countLeaf := LeafFromUint64(uint64(num))
+	countLeaf := LeafFromUint(uint64(num))
 	return NewNodeWithLR(mainTree, countLeaf), nil
 }
 

--- a/tree.go
+++ b/tree.go
@@ -254,28 +254,39 @@ func (n *Node) ProveMulti(indices []int) (*Multiproof, error) {
 	return proof, nil
 }
 
+// LeafFromUint returns a leaf node from a uint8, uint16, uint32, or uint64 value.
+func LeafFromUint[T marshalUints](i T) *Node {
+	buf := make([]byte, 32)
+	copy(buf, MarshalUint(nil, i))
+	return NewNodeWithValue(buf)
+}
+
+// LeafFromUint64 returns a leaf node from a uint64 value.
+//
+// Deprecated: use LeafFromUint instead.
 func LeafFromUint64(i uint64) *Node {
-	buf := make([]byte, 32)
-	binary.LittleEndian.PutUint64(buf[:8], i)
-	return NewNodeWithValue(buf)
+	return LeafFromUint(i)
 }
 
+// LeafFromUint32 returns a leaf node from a uint32 value.
+//
+// Deprecated: use LeafFromUint instead.
 func LeafFromUint32(i uint32) *Node {
-	buf := make([]byte, 32)
-	binary.LittleEndian.PutUint32(buf[:4], i)
-	return NewNodeWithValue(buf)
+	return LeafFromUint(i)
 }
 
+// LeafFromUint16 returns a leaf node from a uint16 value.
+//
+// Deprecated: use LeafFromUint instead.
 func LeafFromUint16(i uint16) *Node {
-	buf := make([]byte, 32)
-	binary.LittleEndian.PutUint16(buf[:2], i)
-	return NewNodeWithValue(buf)
+	return LeafFromUint(i)
 }
 
+// LeafFromUint8 returns a leaf node from a uint8 value.
+//
+// Deprecated: use LeafFromUint instead.
 func LeafFromUint8(i uint8) *Node {
-	buf := make([]byte, 32)
-	buf[0] = byte(i)
-	return NewNodeWithValue(buf)
+	return LeafFromUint(i)
 }
 
 func LeafFromBool(b bool) *Node {

--- a/tree_test.go
+++ b/tree_test.go
@@ -184,3 +184,35 @@ func TestDeprecatedLeafWrappersCallLeafFromUint(t *testing.T) {
 		}
 	}
 }
+
+func TestTreeInternalsUseGenericUintHelpers(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "tree.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "TreeFromNodesWithMixin" {
+			continue
+		}
+		callsLeafFromUint := false
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			ident, ok := call.Fun.(*ast.Ident)
+			if ok && ident.Name == "LeafFromUint" {
+				callsLeafFromUint = true
+			}
+			return true
+		})
+		if !callsLeafFromUint {
+			t.Fatal("expected TreeFromNodesWithMixin to use LeafFromUint")
+		}
+		return
+	}
+	t.Fatal("did not find TreeFromNodesWithMixin")
+}

--- a/tree_test.go
+++ b/tree_test.go
@@ -3,8 +3,13 @@ package ssz
 import (
 	"bytes"
 	"encoding/hex"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"testing"
 )
+
+type treeSlot uint64
 
 func TestTreeFromChunks(t *testing.T) {
 	chunks := [][]byte{
@@ -130,6 +135,52 @@ func TestGetRequiredIndices(t *testing.T) {
 	for i, r := range req {
 		if r != expected[i] {
 			t.Errorf("Invalid required index. Expected %d, got %d\n", expected[i], r)
+		}
+	}
+}
+
+func TestLeafFromUintAcceptsNamedUint64(t *testing.T) {
+	leaf := LeafFromUint(treeSlot(7))
+	want := make([]byte, 32)
+	want[0] = 7
+	if !bytes.Equal(leaf.value, want) {
+		t.Fatalf("unexpected leaf value: %v", leaf.value)
+	}
+}
+
+func TestDeprecatedLeafWrappersCallLeafFromUint(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "tree.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range []string{"LeafFromUint64", "LeafFromUint32", "LeafFromUint16", "LeafFromUint8"} {
+		found := false
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Name.Name != name {
+				continue
+			}
+			found = true
+			if len(fn.Body.List) != 1 {
+				t.Fatalf("expected %s to have exactly one statement", name)
+			}
+			ret, ok := fn.Body.List[0].(*ast.ReturnStmt)
+			if !ok || len(ret.Results) != 1 {
+				t.Fatalf("expected %s to return a direct call", name)
+			}
+			call, ok := ret.Results[0].(*ast.CallExpr)
+			if !ok {
+				t.Fatalf("expected %s to return a call", name)
+			}
+			ident, ok := call.Fun.(*ast.Ident)
+			if !ok || ident.Name != "LeafFromUint" {
+				t.Fatalf("expected %s to call LeafFromUint", name)
+			}
+		}
+		if !found {
+			t.Fatalf("did not find %s", name)
 		}
 	}
 }

--- a/wrapper.go
+++ b/wrapper.go
@@ -14,20 +14,37 @@ func (w *Wrapper) AddBytes(b []byte) {
 	w.AddNode(LeafFromBytes(b))
 }
 
+// AddUint adds a uint8, uint16, uint32, or uint64 leaf node.
+func AddUint[T marshalUints](w *Wrapper, i T) {
+	w.AddNode(LeafFromUint(i))
+}
+
+// AddUint64 adds a uint64 leaf node.
+//
+// Deprecated: use AddUint instead.
 func (w *Wrapper) AddUint64(i uint64) {
-	w.AddNode(LeafFromUint64(i))
+	AddUint(w, i)
 }
 
+// AddUint32 adds a uint32 leaf node.
+//
+// Deprecated: use AddUint instead.
 func (w *Wrapper) AddUint32(i uint32) {
-	w.AddNode(LeafFromUint32(i))
+	AddUint(w, i)
 }
 
+// AddUint16 adds a uint16 leaf node.
+//
+// Deprecated: use AddUint instead.
 func (w *Wrapper) AddUint16(i uint16) {
-	w.AddNode(LeafFromUint16(i))
+	AddUint(w, i)
 }
 
+// AddUint8 adds a uint8 leaf node.
+//
+// Deprecated: use AddUint instead.
 func (w *Wrapper) AddUint8(i uint8) {
-	w.AddNode(LeafFromUint8(i))
+	AddUint(w, i)
 }
 
 func (w *Wrapper) AddNode(n *Node) {

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -1,0 +1,59 @@
+package ssz
+
+import (
+	"bytes"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+type wrapperSlot uint64
+
+func TestAddUintAcceptsNamedUint64(t *testing.T) {
+	var w Wrapper
+	AddUint(&w, wrapperSlot(7))
+
+	want := make([]byte, 32)
+	want[0] = 7
+	if len(w.nodes) != 1 || !bytes.Equal(w.nodes[0].value, want) {
+		t.Fatalf("unexpected node value: %v", w.nodes)
+	}
+}
+
+func TestDeprecatedAddWrappersCallAddUint(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "wrapper.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range []string{"AddUint64", "AddUint32", "AddUint16", "AddUint8"} {
+		found := false
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Name.Name != name {
+				continue
+			}
+			found = true
+			if len(fn.Body.List) != 1 {
+				t.Fatalf("expected %s to have exactly one statement", name)
+			}
+			exprStmt, ok := fn.Body.List[0].(*ast.ExprStmt)
+			if !ok {
+				t.Fatalf("expected %s to delegate with a direct call", name)
+			}
+			call, ok := exprStmt.X.(*ast.CallExpr)
+			if !ok {
+				t.Fatalf("expected %s body to be a call", name)
+			}
+			ident, ok := call.Fun.(*ast.Ident)
+			if !ok || ident.Name != "AddUint" {
+				t.Fatalf("expected %s to call AddUint", name)
+			}
+		}
+		if !found {
+			t.Fatalf("did not find %s", name)
+		}
+	}
+}


### PR DESCRIPTION
Results:
- go test . — passes                                                                                                                                                                                                - go test ./sszgen — passes                                                                                                                                                                                          
- go test ./spectests/... — passes                                                                                                                                                                                   
- go test ./tests — passes                                                                                                                                                                                           
- go test ./... — still fails only in the pre-existing unrelated sszgen/generator package 

The intention is to support use of uint type aliases in slices like `[]primitives.ValidatorIndex` in Prysm.